### PR TITLE
Update Utils.java

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
@@ -69,7 +69,13 @@ public class Utils {
                     for (int j = 0; j < row.length(); j++) {
                         rowVector.add(row.getString(j));
                     }
-                    values.add(rowVector);
+                    Object obj = row.get(j);
+                    rowVector.add(row.getString(j));
+	                if(obj == JSONObject.NULL){		
+	                    rowVector.add("");		
+	                } else {		
+	                    rowVector.add(obj.toString());		
+	                }
                 }
 
                 return new KustoResults(columnNameToIndex, columnNameToType, values);


### PR DESCRIPTION
fix: Kusto now returns null cells which cannot be cast to string, thus failing the getString method.