### PR TITLE
Expose a method 'GetBlobUriFromClientResourceManager' to get temporary blob uri for ingestion

### DIFF
--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClient.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClient.java
@@ -64,6 +64,13 @@ public interface IngestClient {
      * @throws IngestionClientException  An exception originating from a client activity
      * @throws IngestionServiceException An exception returned from the service
      */
-    IngestionResult ingestFromStream(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties) throws IngestionClientException, IngestionServiceException;
 
+    IngestionResult ingestFromStream(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties) throws IngestionClientException, IngestionServiceException;
+    /**
+     * Generate a temporary blob uri that can be used to ingest with this client
+     * @return The blob uri
+     * @throws IngestionClientException An exception originating from a client activity
+     * @throws IngestionServiceException An exception returned from the service
+     */
+    String GetTempBlobUriFromClientResourceManager() throws IngestionClientException, IngestionServiceException;
 }

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientImpl.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientImpl.java
@@ -134,7 +134,7 @@ class IngestClientImpl implements IngestClient {
         try {
             String fileName = (new File(fileSourceInfo.getFilePath())).getName();
             String blobName = genBlobName(fileName, ingestionProperties.getDatabaseName(), ingestionProperties.getTableName());
-            CloudBlockBlob blob = azureStorageHelper.uploadLocalFileToBlob(fileSourceInfo.getFilePath(), blobName, resourceManager.getIngestionResource(ResourceManager.ResourceType.TEMP_STORAGE));
+            CloudBlockBlob blob = azureStorageHelper.uploadLocalFileToBlob(fileSourceInfo.getFilePath(), blobName, GetTempBlobUriFromClientResourceManager());
             String blobPath = azureStorageHelper.getBlobPathWithSas(blob);
             long rawDataSize = fileSourceInfo.getRawSizeInBytes() > 0L ? fileSourceInfo.getRawSizeInBytes() :
                     estimateFileRawSize(fileSourceInfo.getFilePath());
@@ -168,7 +168,7 @@ class IngestClientImpl implements IngestClient {
             CloudBlockBlob blob = azureStorageHelper.uploadStreamToBlob(
                     streamSourceInfo.getStream(),
                     blobName,
-                    resourceManager.getIngestionResource(ResourceManager.ResourceType.TEMP_STORAGE),
+                    GetTempBlobUriFromClientResourceManager(),
                     true
             );
             String blobPath = azureStorageHelper.getBlobPathWithSas(blob);
@@ -338,4 +338,7 @@ class IngestClientImpl implements IngestClient {
                 ;
     }
 
+    public String GetTempBlobUriFromClientResourceManager() throws IngestionClientException, IngestionServiceException {
+        return resourceManager.getIngestionResource(ResourceManager.ResourceType.TEMP_STORAGE);
+    }
 }


### PR DESCRIPTION
Expose a method 'GetBlobUriFromClientResourceManager' to get temporary blob uri for ingestion