### PR TITLE
changing Results impl using java interfaces instead than concrete imp…

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/Results.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Results.java
@@ -1,27 +1,31 @@
 package com.microsoft.azure.kusto.data;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.*;
 
 public class Results {
-    private HashMap<String, Integer> columnNameToIndex;
-    private HashMap<String, String> columnNameToType;
-    private ArrayList<ArrayList<String>> values;
-    private String exceptionsMessages;
+    private final Map<String, Integer> columnNameToIndex;
+    private final List<String> headers;
+    private final Map<String, String> columnNameToType;
+    private final List<List<String>> values;
+    private final String exceptionsMessages;
 
-    public Results(HashMap<String, Integer> columnNameToIndex, HashMap<String, String> columnNameToType,
-                   ArrayList<ArrayList<String>> values, String exceptionsMessages) {
+    public Results(Map<String, Integer> columnNameToIndex,
+                   List<String> headers,
+                   Map<String, String> columnNameToType,
+                   List<List<String>> values,
+                   String exceptionsMessages) {
         this.columnNameToIndex = columnNameToIndex;
+        this.headers = headers;
         this.columnNameToType = columnNameToType;
         this.values = values;
         this.exceptionsMessages = exceptionsMessages;
     }
 
-    public HashMap<String, Integer> getColumnNameToIndex() {
+    public Map<String, Integer> getColumnNameToIndex() {
         return columnNameToIndex;
     }
 
-    public HashMap<String, String> getColumnNameToType() {
+    public Map<String, String> getColumnNameToType() {
         return columnNameToType;
     }
 
@@ -33,11 +37,15 @@ public class Results {
         return columnNameToType.get(columnName);
     }
 
-    public ArrayList<ArrayList<String>> getValues() {
+    public List<List<String>> getValues() {
         return values;
     }
 
     public String getExceptions() {
         return exceptionsMessages;
+    }
+
+    public List<String> getHeaders(){
+       return headers;
     }
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 class Utils {
 
@@ -41,7 +43,7 @@ class Utils {
                 : new InputStreamEntity(stream);
         httpPost.setEntity(requestEntity);
         httpPost.addHeader("Accept-Encoding", "gzip,deflate");
-        for (HashMap.Entry<String, String> entry : headers.entrySet()) {
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
             httpPost.addHeader(entry.getKey(), entry.getValue());
         }
 
@@ -62,24 +64,26 @@ class Utils {
                     JSONObject table0 = tablesArray.getJSONObject(0);
                     JSONArray resultsColumns = table0.getJSONArray("Columns");
 
-                    HashMap<String, Integer> columnNameToIndex = new HashMap<>();
-                    HashMap<String, String> columnNameToType = new HashMap<>();
+                    Map<String, Integer> columnNameToIndex = new HashMap<>();
+                    List<String>  columns = new ArrayList<>();
+                    Map<String, String> columnNameToType = new HashMap<>();
                     for (int i = 0; i < resultsColumns.length(); i++) {
                         JSONObject column = resultsColumns.getJSONObject(i);
                         String columnName = column.getString("ColumnName");
                         columnNameToIndex.put(columnName, i);
+                        columns.add(columnName);
                         columnNameToType.put(columnName, column.getString("DataType"));
                     }
 
                     JSONArray resultsRows = table0.getJSONArray("Rows");
-                    ArrayList<ArrayList<String>> values = new ArrayList<>();
+                    List<List<String>> values = new ArrayList<>();
                     for (int i = 0; i < resultsRows.length(); i++) {
                         Object row = resultsRows.get(i);
                         if (row instanceof JSONObject) {
                             exceptions = ((JSONObject) row).get("Exceptions").toString();
                         }
                         JSONArray rowAsJsonArray = resultsRows.getJSONArray(i);
-                        ArrayList<String> rowVector = new ArrayList<>();
+                        List<String> rowVector = new ArrayList<>();
                         for (int j = 0; j < rowAsJsonArray.length(); ++j) {
                             Object obj = rowAsJsonArray.get(j);
                             if (obj == JSONObject.NULL) {
@@ -91,7 +95,7 @@ class Utils {
                         values.add(rowVector);
                     }
 
-                    return new Results(columnNameToIndex, columnNameToType, values, exceptions);
+                    return new Results(columnNameToIndex,columns, columnNameToType, values, exceptions);
                 } else {
                     throw new DataServiceException(url, "Error in post request", new DataWebException(responseContent, response));
                 }

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ResourceManagerTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ResourceManagerTest.java
@@ -104,9 +104,11 @@ class ResourceManagerTest {
     }
 
     private static Results generateIngestionResourcesResult() {
-        HashMap<String, Integer> colNameToIndexMap = new HashMap<>();
-        HashMap<String, String> colNameToTypeMap = new HashMap<>();
-        ArrayList<ArrayList<String>> valuesList = new ArrayList<>();
+        Map<String, Integer> colNameToIndexMap = new HashMap<>();
+        Map<String, String> colNameToTypeMap = new HashMap<>();
+        List<List<String>> valuesList = new ArrayList<>();
+        List<String> headers = new ArrayList<>();
+        headers.add("AuthorizationContext");
 
         colNameToIndexMap.put("colNameToIndexMap", 0);
         colNameToIndexMap.put("StorageRoot", 1);
@@ -122,18 +124,20 @@ class ResourceManagerTest {
         valuesList.add(new ArrayList<>((Arrays.asList("TempStorage", STORAGE_2))));
         valuesList.add(new ArrayList<>((Arrays.asList("IngestionsStatusTable", STATUS_TABLE))));
 
-        return new Results(colNameToIndexMap, colNameToTypeMap, valuesList, "");
+        return new Results(colNameToIndexMap, headers, colNameToTypeMap, valuesList, "");
     }
 
     private static Results generateIngestionAuthTokenResult() {
-        HashMap<String, Integer> colNameToIndexMap = new HashMap<>();
-        HashMap<String, String> colNameToTypeMap = new HashMap<>();
-        ArrayList<ArrayList<String>> valuesList = new ArrayList<>();
+        Map<String, Integer> colNameToIndexMap = new HashMap<>();
+        Map<String, String> colNameToTypeMap = new HashMap<>();
+        List<List<String>> valuesList = new ArrayList<>();
+        List<String> headers = new ArrayList<>();
+        headers.add("AuthorizationContext");
 
         colNameToIndexMap.put("AuthorizationContext", 0);
         colNameToTypeMap.put("AuthorizationContext", "String");
         valuesList.add(new ArrayList<>((Collections.singletonList(AUTH_TOKEN))));
 
-        return new Results(colNameToIndexMap, colNameToTypeMap, valuesList, "");
+        return new Results(colNameToIndexMap, headers, colNameToTypeMap, valuesList, "");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </developers>
 
     <properties>
-        <revision>1.1.0</revision> <!-- CHANGE THIS to adjust project version-->
+        <revision>1.2.0-SNAPSHOT</revision> <!-- CHANGE THIS to adjust project version-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
 


### PR DESCRIPTION
I have slightly changed the signature of  `Results` class, exposing java interfaces (Map,List) rather than concrete impl (HashMap, ArrayList).
This breaks compatibility, so I increased version to 1.2.0-snapshot.

I also added the `headers()` method to return headers in order

what you think?

