### PR TITLE
Fix - ColumnMapping serialization

### DIFF
--- a/ingest/pom.xml
+++ b/ingest/pom.xml
@@ -142,6 +142,11 @@
             <version>${fasterxml.jackson.core.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${fasterxml.jackson.core.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.univocity</groupId>
             <artifactId>univocity-parsers</artifactId>
             <version>2.1.1</version>

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionProperties.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionProperties.java
@@ -1,5 +1,7 @@
 package com.microsoft.azure.kusto.ingest;
 
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
 
@@ -178,6 +180,8 @@ public class IngestionProperties {
             fullAdditionalProperties.put("ingestionMappingType", ingestionMapping.getIngestionMappingKind().toString());
         } else if (ingestionMapping.getColumnMappings() != null) {
             ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.setVisibility(PropertyAccessor.ALL, Visibility.NONE);
+            objectMapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
 
             String mapping = objectMapper.writeValueAsString(ingestionMapping.getColumnMappings());
             fullAdditionalProperties.put("ingestionMapping", mapping);

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -43,11 +43,6 @@
             <artifactId>jackson-databind</artifactId>
             <version>${fasterxml.jackson.core.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.jackson.core.version}</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -43,6 +43,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${fasterxml.jackson.core.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${fasterxml.jackson.core.version}</version>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
Currently ObjectMapper serialize ColumnMapping's properties and getters, therefore if for example we have "Path" in the properties we will get it twice - from "properties" Map field and from getPath(), this will cause ingestion failure in the Engine (when it try to desrialize the mapping)