### PR TITLE
Add missing ApacheAvro format

### DIFF
--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ColumnMapping.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ColumnMapping.java
@@ -96,6 +96,7 @@ public class ColumnMapping implements Serializable {
                         || transformationMethod == TransformationMethod.SourceLineNumber
                         || transformationMethod == TransformationMethod.SourceLocation);
             case Avro:
+            case ApacheAvro:
                 return !StringUtils.isEmpty(this.columnName) &&
                         !StringUtils.isEmpty(getColumns());
             default:

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionMapping.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionMapping.java
@@ -13,7 +13,7 @@ public class IngestionMapping {
     private ColumnMapping[] columnMappings;
     private IngestionMappingKind ingestionMappingKind;
     private String ingestionMappingReference;
-    public final static List<String> mappingRequiredFormats = Arrays.asList("json", "singlejson", "avro", "parquet", "orc");
+    public final static List<String> mappingRequiredFormats = Arrays.asList("json", "singlejson", "avro", "apacheavro", "parquet", "orc");
 
     /**
      * Creates a default ingestion mapping with kind Unknown and empty mapping reference.
@@ -82,6 +82,6 @@ public class IngestionMapping {
      Represents an ingestion mapping kind - the format of the source data to map from.
     */
     public enum IngestionMappingKind {
-        unknown, Csv, Json, Parquet, Avro, Orc
+        unknown, Csv, Json, Parquet, Avro, ApacheAvro, Orc
     }
 }

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionProperties.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionProperties.java
@@ -263,7 +263,7 @@ public class IngestionProperties {
         }
     }
 
-    public enum DATA_FORMAT {csv, tsv, scsv, sohsv, psv, txt, tsve, json, singlejson, multijson, avro, parquet, orc}
+    public enum DATA_FORMAT {csv, tsv, scsv, sohsv, psv, txt, tsve, json, singlejson, multijson, avro, apacheavro, parquet, orc}
 
     public enum IngestionReportLevel {
         FailuresOnly,


### PR DESCRIPTION
Added `ApacheAvro` format to the supported formats list.
The `ApacheAvro` format refers to a newer implementation of Avro parser in Kusto engine.
