### PR TITLE
Server timeout fix

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
@@ -25,6 +25,7 @@ public class ClientImpl implements Client, StreamingClient {
     private static final Long COMMAND_TIMEOUT_IN_MILLISECS = TimeUnit.MINUTES.toMillis(10) + TimeUnit.SECONDS.toMillis(30);
     private static final Long QUERY_TIMEOUT_IN_MILLISECS = TimeUnit.MINUTES.toMillis(4) + TimeUnit.SECONDS.toMillis(30);
     private static final Long STREAMING_INGEST_TIMEOUT_IN_MILLISECS = TimeUnit.MINUTES.toMillis(10);
+    private static final int CLIENT_SERVER_DELTA_IN_MILLISECS = (int) TimeUnit.SECONDS.toMillis(30);
 
     private AadAuthenticationHelper aadAuthenticationHelper;
     private String clusterUrl;
@@ -96,7 +97,7 @@ public class ClientImpl implements Client, StreamingClient {
         headers.put("x-ms-client-request-id", String.format("KJC.execute;%s", java.util.UUID.randomUUID()));
         headers.put("Fed", "True");
 
-        return Utils.post(clusterEndpoint, jsonString, null, timeoutMs.intValue(), headers, false);
+        return Utils.post(clusterEndpoint, jsonString, null, timeoutMs.intValue() + CLIENT_SERVER_DELTA_IN_MILLISECS, headers, false);
     }
 
     @Override
@@ -135,7 +136,7 @@ public class ClientImpl implements Client, StreamingClient {
         if (timeoutMs == null) {
             timeoutMs = STREAMING_INGEST_TIMEOUT_IN_MILLISECS;
         }
-        return Utils.post(clusterEndpoint, null, stream, timeoutMs.intValue(), headers, leaveOpen);
+        return Utils.post(clusterEndpoint, null, stream, timeoutMs.intValue()  + CLIENT_SERVER_DELTA_IN_MILLISECS, headers, leaveOpen);
     }
 
     private HashMap<String, String> initHeaders() throws DataServiceException {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
@@ -81,13 +81,31 @@ public class ClientRequestProperties {
 
     JSONObject toJson() {
         try {
+            JSONObject optionsAsJSON = new JSONObject(this.options);
+            Long timeoutInMilliSec = getTimeoutInMilliSec();
+            if(timeoutInMilliSec != null) {
+                optionsAsJSON.put(OPTION_SERVER_TIMEOUT, msToTimespan(timeoutInMilliSec));
+            }
             JSONObject json = new JSONObject();
-            json.put(OPTIONS_KEY, new JSONObject(this.options));
+            json.put(OPTIONS_KEY, optionsAsJSON);
             json.put(PARAMETERS_KEY, new JSONObject(this.parameters));
             return json;
         } catch (JSONException e) {
             return null;
         }
+    }
+
+    private static String msToTimespan(Long duration) {
+        long milliseconds = duration % 1000;
+        long seconds = (duration / 1000) % 60;
+        long minutes = (duration / (1000 * 60)) % 60;
+        long hours = (duration / (1000 * 60 * 60)) % 24;
+
+        String hoursString = (hours < 10) ? "0" + hours : String.valueOf(hours);
+        String minutesString = (minutes < 10) ? "0" + minutes : String.valueOf(minutes);
+        String secondsString = (seconds < 10) ? "0" + seconds : String.valueOf(seconds);
+
+        return hoursString + ":" + minutesString + ":" + secondsString + "." + String.valueOf(milliseconds);
     }
 
     public String toString() {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
@@ -7,6 +7,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.time.LocalTime;
 import java.util.HashMap;
 import java.util.Iterator;
 
@@ -21,6 +22,7 @@ public class ClientRequestProperties {
     private static final String OPTIONS_KEY = "Options";
     private static final String PARAMETERS_KEY = "Parameters";
     private static final String OPTION_SERVER_TIMEOUT = "servertimeout";
+    private static final long NANOS_TO_MILLIS = 1000000L;
     private HashMap<String, Object> parameters;
     private HashMap<String, Object> options;
 
@@ -66,12 +68,12 @@ public class ClientRequestProperties {
         Long timeout = null;
         if (timeoutObj instanceof Long) {
             timeout = (Long) timeoutObj;
-        }
-        if (timeoutObj instanceof String) {
-            timeout = Long.valueOf((String) timeoutObj);
+        } else if (timeoutObj instanceof String) {
+            timeout = LocalTime.parse((String) timeoutObj).toNanoOfDay() / NANOS_TO_MILLIS;
         } else if (timeoutObj instanceof Integer) {
             timeout = Long.valueOf((Integer) timeoutObj);
         }
+
         return timeout;
     }
 
@@ -83,8 +85,9 @@ public class ClientRequestProperties {
         try {
             JSONObject optionsAsJSON = new JSONObject(this.options);
             Long timeoutInMilliSec = getTimeoutInMilliSec();
-            if(timeoutInMilliSec != null) {
-                optionsAsJSON.put(OPTION_SERVER_TIMEOUT, msToTimespan(timeoutInMilliSec));
+            if (timeoutInMilliSec != null) {
+                LocalTime localTime = LocalTime.ofNanoOfDay(timeoutInMilliSec * NANOS_TO_MILLIS);
+                optionsAsJSON.put(OPTION_SERVER_TIMEOUT, localTime.toString());
             }
             JSONObject json = new JSONObject();
             json.put(OPTIONS_KEY, optionsAsJSON);
@@ -93,19 +96,6 @@ public class ClientRequestProperties {
         } catch (JSONException e) {
             return null;
         }
-    }
-
-    private static String msToTimespan(Long duration) {
-        long milliseconds = duration % 1000;
-        long seconds = (duration / 1000) % 60;
-        long minutes = (duration / (1000 * 60)) % 60;
-        long hours = (duration / (1000 * 60 * 60)) % 24;
-
-        String hoursString = (hours < 10) ? "0" + hours : String.valueOf(hours);
-        String minutesString = (minutes < 10) ? "0" + minutes : String.valueOf(minutes);
-        String secondsString = (seconds < 10) ? "0" + seconds : String.valueOf(seconds);
-
-        return hoursString + ":" + minutesString + ":" + secondsString + "." + String.valueOf(milliseconds);
     }
 
     public String toString() {

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -38,9 +38,10 @@ public class ClientRequestPropertiesTest {
     @Test
     @DisplayName("test ClientRequestProperties fromString")
     void stringToProperties() throws JSONException {
-        String properties = "{\"Options\":{\"servertimeout\":100000, \"Content-Encoding\":\"gzip\"},\"Parameters\":{\"birthday\":\"datetime(1970-05-11)\",\"courses\":\"dynamic(['Java', 'C++'])\"}}";
+        String properties = "{\"Options\":{\"servertimeout\":5111111, \"Content-Encoding\":\"gzip\"},\"Parameters\":{\"birthday\":\"datetime(1970-05-11)\",\"courses\":\"dynamic(['Java', 'C++'])\"}}";
         ClientRequestProperties crp = ClientRequestProperties.fromString(properties);
-
+        assert crp != null;
+        assert crp.toJson().getJSONObject("Options").get("servertimeout").equals("01:25:11.111");
         assert crp.getTimeoutInMilliSec() != null;
         assert crp.getOption("Content-Encoding").equals("gzip");
         assert crp.getParameter("birthday").equals("datetime(1970-05-11)");

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -38,7 +38,7 @@ public class ClientRequestPropertiesTest {
     @Test
     @DisplayName("test ClientRequestProperties fromString")
     void stringToProperties() throws JSONException {
-        String properties = "{\"Options\":{\"servertimeout\":5111111, \"Content-Encoding\":\"gzip\"},\"Parameters\":{\"birthday\":\"datetime(1970-05-11)\",\"courses\":\"dynamic(['Java', 'C++'])\"}}";
+        String properties = "{\"Options\":{\"servertimeout\":\"01:25:11.111\", \"Content-Encoding\":\"gzip\"},\"Parameters\":{\"birthday\":\"datetime(1970-05-11)\",\"courses\":\"dynamic(['Java', 'C++'])\"}}";
         ClientRequestProperties crp = ClientRequestProperties.fromString(properties);
         assert crp != null;
         assert crp.toJson().getJSONObject("Options").get("servertimeout").equals("01:25:11.111");


### PR DESCRIPTION
#### Pull Request Description

Format server timeout as a timespan 

---

#### Future Release Comment

**Breaking Changes:**
- Calling ClientRequestProperties.getTimeoutInMilliSec over a timeout option set with string is expecting the string to represent a LocalTime object.

**Features:**
- Client side timeout is calculated by server timeout plus 30 seconds

**Fixes:**
- servertimeout is using now in the right format and will result with real limit on the server timeout
