### PR TITLE
Expose authority id for all authenticaiton methods

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/AadAuthenticationHelper.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/AadAuthenticationHelper.java
@@ -197,7 +197,7 @@ class AadAuthenticationHelper {
 
     private AuthenticationResult waitAndAcquireTokenByDeviceCode(DeviceCode deviceCode, AuthenticationContext context)
             throws InterruptedException {
-        int timeout = 20 * 1000;
+        int timeout = 60 * 1000;
         AuthenticationResult result = null;
         while (timeout > 0) {
             try {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ConnectionStringBuilder.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ConnectionStringBuilder.java
@@ -147,17 +147,31 @@ public class ConnectionStringBuilder {
         return createWithAadApplicationCredentials(resourceUri, applicationClientId, applicationKey, null);
     }
 
-    public static ConnectionStringBuilder createWithDeviceCodeCredentials(String resourceUri) {
+    public static ConnectionStringBuilder createWithDeviceCodeCredentials(String resourceUri, String authorityId) {
         if (StringUtils.isEmpty(resourceUri)) {
             throw new IllegalArgumentException("resourceUri cannot be null or empty");
         }
-        return new ConnectionStringBuilder(resourceUri);
+
+        ConnectionStringBuilder csb = new ConnectionStringBuilder(resourceUri);
+        csb.aadAuthorityId = authorityId;
+        return csb;
+    }
+
+    public static ConnectionStringBuilder createWithDeviceCodeCredentials(String resourceUri) {
+        return createWithDeviceCodeCredentials(resourceUri, null);
     }
 
     public static ConnectionStringBuilder createWithAadApplicationCertificate(String resourceUri,
                                                                               String applicationClientId,
                                                                               X509Certificate x509Certificate,
                                                                               PrivateKey privateKey) {
+        return createWithAadApplicationCertificate(resourceUri, applicationClientId, x509Certificate, privateKey, null);
+    }
+    public static ConnectionStringBuilder createWithAadApplicationCertificate(String resourceUri,
+                                                                              String applicationClientId,
+                                                                              X509Certificate x509Certificate,
+                                                                              PrivateKey privateKey,
+                                                                              String authorityId) {
         if (StringUtils.isEmpty(resourceUri)) {
             throw new IllegalArgumentException("resourceUri cannot be null or empty");
         }
@@ -175,6 +189,7 @@ public class ConnectionStringBuilder {
         csb.applicationClientId = applicationClientId;
         csb.x509Certificate = x509Certificate;
         csb.privateKey = privateKey;
+        csb.aadAuthorityId = authorityId;
         return csb;
     }
 

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ConnectionStringBuilder.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ConnectionStringBuilder.java
@@ -11,6 +11,7 @@ import java.util.concurrent.Callable;
 
 public class ConnectionStringBuilder {
 
+    private final static String DEFAULT_DEVICE_AUTH_TENANT = "common";
     private String clusterUri;
     private String username;
     private String password;
@@ -158,7 +159,7 @@ public class ConnectionStringBuilder {
     }
 
     public static ConnectionStringBuilder createWithDeviceCodeCredentials(String resourceUri) {
-        return createWithDeviceCodeCredentials(resourceUri, null);
+        return createWithDeviceCodeCredentials(resourceUri, DEFAULT_DEVICE_AUTH_TENANT);
     }
 
     public static ConnectionStringBuilder createWithAadApplicationCertificate(String resourceUri,

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     </developers>
 
     <properties>
-        <revision>2.3.1</revision> <!-- CHANGE THIS to adjust project version-->
+        <revision>2.3.2</revision> <!-- CHANGE THIS to adjust project version-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
 


### PR DESCRIPTION

**Fixes:**
- Device authentication and certificate authentication did not expose a way to set authority id 
