### PR TITLE
Add new API to query returning a json result

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/Client.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Client.java
@@ -7,10 +7,15 @@ import com.microsoft.azure.kusto.data.exceptions.DataClientException;
 import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
 
 public interface Client {
-
     KustoOperationResult execute(String command) throws DataServiceException, DataClientException;
 
     KustoOperationResult execute(String database, String command) throws DataServiceException, DataClientException;
 
     KustoOperationResult execute(String database, String command, ClientRequestProperties properties) throws DataServiceException, DataClientException;
+
+    String executeForJsonResult(String database) throws DataServiceException, DataClientException;
+
+    String executeForJsonResult(String database, String command) throws DataServiceException, DataClientException;
+
+    String executeForJsonResult(String database, String command, ClientRequestProperties properties) throws DataServiceException, DataClientException;
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/Client.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Client.java
@@ -13,9 +13,9 @@ public interface Client {
 
     KustoOperationResult execute(String database, String command, ClientRequestProperties properties) throws DataServiceException, DataClientException;
 
-    String executeForJsonResult(String database) throws DataServiceException, DataClientException;
+    String executeToJsonResult(String database) throws DataServiceException, DataClientException;
 
-    String executeForJsonResult(String database, String command) throws DataServiceException, DataClientException;
+    String executeToJsonResult(String database, String command) throws DataServiceException, DataClientException;
 
-    String executeForJsonResult(String database, String command, ClientRequestProperties properties) throws DataServiceException, DataClientException;
+    String executeToJsonResult(String database, String command, ClientRequestProperties properties) throws DataServiceException, DataClientException;
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
@@ -73,7 +73,7 @@ public class ClientImpl implements Client, StreamingClient {
 
     @Override
     public KustoOperationResult execute(String database, String command, ClientRequestProperties properties) throws DataServiceException, DataClientException {
-        String response = executeForJsonResult(database, command, properties);
+        String response = executeToJsonResult(database, command, properties);
 
         String clusterEndpoint = determineClusterEndpoint(command);
         try {
@@ -84,17 +84,17 @@ public class ClientImpl implements Client, StreamingClient {
     }
 
     @Override
-    public String executeForJsonResult(String command) throws DataServiceException, DataClientException {
-        return executeForJsonResult(DEFAULT_DATABASE_NAME, command);
+    public String executeToJsonResult(String command) throws DataServiceException, DataClientException {
+        return executeToJsonResult(DEFAULT_DATABASE_NAME, command);
     }
 
     @Override
-    public String executeForJsonResult(String database, String command) throws DataServiceException, DataClientException {
-        return executeForJsonResult(database, command, null);
+    public String executeToJsonResult(String database, String command) throws DataServiceException, DataClientException {
+        return executeToJsonResult(database, command, null);
     }
 
     @Override
-    public String executeForJsonResult(String database, String command, ClientRequestProperties properties) throws DataServiceException, DataClientException {
+    public String executeToJsonResult(String database, String command, ClientRequestProperties properties) throws DataServiceException, DataClientException {
         // Argument validation
         if (StringUtils.isEmpty(database)) {
             throw new IllegalArgumentException("Database is empty");

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
@@ -95,10 +95,15 @@ public class ClientImpl implements Client, StreamingClient {
 
     @Override
     public String executeForJsonResult(String database, String command, ClientRequestProperties properties) throws DataServiceException, DataClientException {
-        // Argument validation:
-        if (StringUtils.isAnyEmpty(database, command)) {
-            throw new IllegalArgumentException("Database and/or command is empty");
+        // Argument validation
+        if (StringUtils.isEmpty(database)) {
+            throw new IllegalArgumentException("Database is empty");
         }
+        if (StringUtils.isEmpty(command)) {
+            throw new IllegalArgumentException("Command is empty");
+        }
+        command = command.trim();
+
         Long timeoutMs = properties == null ? null : properties.getTimeoutInMilliSec();
 
         String clusterEndpoint = determineClusterEndpoint(command);

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
@@ -181,7 +181,7 @@ public class ClientImpl implements Client, StreamingClient {
         }
         String response = Utils.post(clusterEndpoint, null, stream, timeoutMs.intValue() + CLIENT_SERVER_DELTA_IN_MILLISECS, headers, leaveOpen);
         try {
-            return new KustoOperationResult(response, clusterEndpoint.endsWith("v2/rest/query") ? "v2" : "v1");
+            return new KustoOperationResult(response, "v1");
         } catch (KustoServiceError e) {
             throw new DataClientException(clusterEndpoint, "Error converting json response to KustoOperationResult:" + e.getMessage(), e);
         }

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
@@ -4,14 +4,20 @@
 package com.microsoft.azure.kusto.ingest;
 
 import com.microsoft.azure.kusto.data.ClientImpl;
+import com.microsoft.azure.kusto.data.ClientRequestProperties;
 import com.microsoft.azure.kusto.data.KustoOperationResult;
 import com.microsoft.azure.kusto.data.KustoResultSetTable;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
+import com.microsoft.azure.kusto.data.exceptions.DataClientException;
+import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
 import com.microsoft.azure.kusto.ingest.IngestionMapping.IngestionMappingKind;
 import com.microsoft.azure.kusto.ingest.IngestionProperties.DATA_FORMAT;
 import com.microsoft.azure.kusto.ingest.source.CompressionType;
 import com.microsoft.azure.kusto.ingest.source.FileSourceInfo;
 import com.microsoft.azure.kusto.ingest.source.StreamSourceInfo;
+import org.apache.commons.lang3.time.StopWatch;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,8 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 class E2ETest {
     private static IngestClient ingestClient;
@@ -73,21 +78,20 @@ class E2ETest {
     @AfterAll
     public static void tearDown() {
         try {
-            queryClient.execute(databaseName, String.format(".drop table %s ifexists", tableName));
+            queryClient.executeForJsonResult(databaseName, String.format(".drop table %s ifexists", tableName));
         } catch (Exception ex) {
             Assertions.fail("Failed to drop table", ex);
         }
     }
 
     private static void CreateTableAndMapping() {
-        KustoOperationResult result;
         try {
-            result = queryClient.execute(databaseName, String.format(".drop table %s ifexists", tableName));
+            queryClient.executeForJsonResult(databaseName, String.format(".drop table %s ifexists", tableName));
         } catch (Exception ex) {
         }
         try {
             Thread.sleep(2000);
-            result = queryClient.execute(databaseName, String.format(".create table %s %s", tableName, tableColumns));
+            queryClient.executeForJsonResult(databaseName, String.format(".create table %s %s", tableName, tableColumns));
         } catch (Exception ex) {
             Assertions.fail("Failed to drop and create new table", ex);
         }
@@ -96,7 +100,7 @@ class E2ETest {
         try {
             Thread.sleep(2000);
             String mappingAsString = new String(Files.readAllBytes(Paths.get(resourcesPath, "dataset_mapping.json")));
-            result = queryClient.execute(databaseName, String.format(".create table %s ingestion json mapping '%s' '%s'",
+            queryClient.executeForJsonResult(databaseName, String.format(".create table %s ingestion json mapping '%s' '%s'",
                     tableName, mappingReference, mappingAsString));
         } catch (Exception ex) {
             Assertions.fail("Failed to create ingestion mapping", ex);
@@ -163,8 +167,7 @@ class E2ETest {
         });
     }
 
-    private void assertRowCount(int expectedRowsCount) {
-        KustoOperationResult result;
+    private void assertRowCount(int expectedRowsCount, boolean checkViaJson) {
         int timeoutInSec = 100;
         int actualRowsCount = 0;
 
@@ -173,13 +176,28 @@ class E2ETest {
                 Thread.sleep(5000);
                 timeoutInSec -= 5;
 
-                result = queryClient.execute(databaseName, String.format("%s | count", tableName));
+                if (checkViaJson) {
+                    String result = queryClient.executeForJsonResult(databaseName, String.format("%s | count", tableName));
+                    JSONArray jsonArray = new JSONArray(result);
+                    JSONObject primaryResult = null;
+                    for (Object o : jsonArray) {
+                        if (o.toString() != null && o.toString().matches(".*\"TableKind\"\\s*:\\s*\"PrimaryResult\".*")) {
+                            primaryResult = new JSONObject(o.toString());
+                            break;
+                        }
+                    }
+                    assertNotNull(primaryResult);
+                    actualRowsCount = (Integer) ((JSONArray) ((JSONArray) primaryResult.get("Rows")).get(0)).get(0) - currentCount;
+                } else {
+                    KustoOperationResult result = queryClient.execute(databaseName, String.format("%s | count", tableName));
+                    KustoResultSetTable mainTableResult = result.getPrimaryResults();
+                    mainTableResult.next();
+                    actualRowsCount = mainTableResult.getInt(0) - currentCount;
+                }
             } catch (Exception ex) {
                 continue;
             }
-            KustoResultSetTable mainTableResult = result.getPrimaryResults();
-            mainTableResult.next();
-            actualRowsCount = mainTableResult.getInt(0) - currentCount;
+
             if (actualRowsCount >= expectedRowsCount) {
                 break;
             }
@@ -221,7 +239,7 @@ class E2ETest {
             } catch (Exception ex) {
                 Assertions.fail(ex);
             }
-            assertRowCount(item.rows);
+            assertRowCount(item.rows, false);
         }
     }
 
@@ -238,7 +256,7 @@ class E2ETest {
             } catch (Exception ex) {
                 Assertions.fail(ex);
             }
-            assertRowCount(item.rows);
+            assertRowCount(item.rows, true);
         }
     }
 
@@ -252,7 +270,7 @@ class E2ETest {
                 } catch (Exception ex) {
                     Assertions.fail(ex);
                 }
-                assertRowCount(item.rows);
+                assertRowCount(item.rows, false);
             }
         }
     }
@@ -271,7 +289,7 @@ class E2ETest {
                 } catch (Exception ex) {
                     Assertions.fail(ex);
                 }
-                assertRowCount(item.rows);
+                assertRowCount(item.rows, true);
             }
         }
     }

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
@@ -4,18 +4,14 @@
 package com.microsoft.azure.kusto.ingest;
 
 import com.microsoft.azure.kusto.data.ClientImpl;
-import com.microsoft.azure.kusto.data.ClientRequestProperties;
 import com.microsoft.azure.kusto.data.KustoOperationResult;
 import com.microsoft.azure.kusto.data.KustoResultSetTable;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
-import com.microsoft.azure.kusto.data.exceptions.DataClientException;
-import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
 import com.microsoft.azure.kusto.ingest.IngestionMapping.IngestionMappingKind;
 import com.microsoft.azure.kusto.ingest.IngestionProperties.DATA_FORMAT;
 import com.microsoft.azure.kusto.ingest.source.CompressionType;
 import com.microsoft.azure.kusto.ingest.source.FileSourceInfo;
 import com.microsoft.azure.kusto.ingest.source.StreamSourceInfo;
-import org.apache.commons.lang3.time.StopWatch;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.AfterAll;
@@ -78,7 +74,7 @@ class E2ETest {
     @AfterAll
     public static void tearDown() {
         try {
-            queryClient.executeForJsonResult(databaseName, String.format(".drop table %s ifexists", tableName));
+            queryClient.executeToJsonResult(databaseName, String.format(".drop table %s ifexists", tableName));
         } catch (Exception ex) {
             Assertions.fail("Failed to drop table", ex);
         }
@@ -86,12 +82,12 @@ class E2ETest {
 
     private static void CreateTableAndMapping() {
         try {
-            queryClient.executeForJsonResult(databaseName, String.format(".drop table %s ifexists", tableName));
+            queryClient.executeToJsonResult(databaseName, String.format(".drop table %s ifexists", tableName));
         } catch (Exception ex) {
         }
         try {
             Thread.sleep(2000);
-            queryClient.executeForJsonResult(databaseName, String.format(".create table %s %s", tableName, tableColumns));
+            queryClient.executeToJsonResult(databaseName, String.format(".create table %s %s", tableName, tableColumns));
         } catch (Exception ex) {
             Assertions.fail("Failed to drop and create new table", ex);
         }
@@ -100,7 +96,7 @@ class E2ETest {
         try {
             Thread.sleep(2000);
             String mappingAsString = new String(Files.readAllBytes(Paths.get(resourcesPath, "dataset_mapping.json")));
-            queryClient.executeForJsonResult(databaseName, String.format(".create table %s ingestion json mapping '%s' '%s'",
+            queryClient.executeToJsonResult(databaseName, String.format(".create table %s ingestion json mapping '%s' '%s'",
                     tableName, mappingReference, mappingAsString));
         } catch (Exception ex) {
             Assertions.fail("Failed to create ingestion mapping", ex);
@@ -177,7 +173,7 @@ class E2ETest {
                 timeoutInSec -= 5;
 
                 if (checkViaJson) {
-                    String result = queryClient.executeForJsonResult(databaseName, String.format("%s | count", tableName));
+                    String result = queryClient.executeToJsonResult(databaseName, String.format("%s | count", tableName));
                     JSONArray jsonArray = new JSONArray(result);
                     JSONObject primaryResult = null;
                     for (Object o : jsonArray) {

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.13</httpcore.version>
         <json.version>20201115</json.version>
-        <fasterxml.jackson.core.version>2.12.1</fasterxml.jackson.core.version>
+        <fasterxml.jackson.core.version>[2.11.0,2.12.0)</fasterxml.jackson.core.version>
         <azure-storage.version>8.6.5</azure-storage.version>
         <univocity-parsers.version>2.9.1</univocity-parsers.version>
 


### PR DESCRIPTION
#### Pull Request Description

Add new API to query returning a json result. When the caller doesn't need the Java object, this saves time converting to a Java object in the SDK and from the caller converting from the Java object.

---

#### Future Release Comment
**Features:**
- New Query API that returns a json instead of a KustoOperationResult