### PR TITLE
Exceptions handling

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
@@ -80,7 +80,12 @@ public class ClientImpl implements Client, StreamingClient {
         try {
             return new KustoOperationResult(response, clusterEndpoint.endsWith("v2/rest/query") ? "v2" : "v1");
         } catch (KustoServiceError e) {
-            throw new DataClientException(clusterEndpoint, "Error converting json response to KustoOperationResult:" + e.getMessage(), e);
+            if (e.getExceptions().isEmpty()){
+                throw new DataClientException(clusterEndpoint,
+                        "Error parsing json response as KustoOperationResult:" + e.getMessage(), e);
+            } else {
+                throw new DataServiceException(e.getMessage(), e);
+            }
         }
     }
 

--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
@@ -36,6 +36,7 @@ public class KustoResultSetTable implements ResultSet {
     private static final String COLUMN_TYPE_SECOND_PROPERTY_NAME = "DataType";
     private static final String ROWS_PROPERTY_NAME = "Rows";
     private static final String EXCEPTIONS_PROPERTY_NAME = "Exceptions";
+    private static final String EXCEPTIONS_MESSAGE = "Query execution failed with inner exceptions";
 
     private final List<List<Object>> rows;
     private String tableName;
@@ -107,11 +108,11 @@ public class KustoResultSetTable implements ResultSet {
                             String message = exceptions.getString(0);
                             throw new KustoServiceError(message);
                         } else {
-                            throw new KustoServiceError(exceptions, false);
+                            throw new KustoServiceError(exceptions, false, EXCEPTIONS_MESSAGE);
                         }
                     } else {
                         throw new KustoServiceError(((JSONObject) row).getJSONArray(
-                                "OneApiErrors"),true);
+                                "OneApiErrors"),true, EXCEPTIONS_MESSAGE);
                     }
                 }
                 JSONArray rowAsJsonArray = jsonRows.getJSONArray(i);

--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
@@ -3,7 +3,9 @@
 
 package com.microsoft.azure.kusto.data;
 
+import com.microsoft.azure.kusto.data.exceptions.DataWebException;
 import com.microsoft.azure.kusto.data.exceptions.KustoServiceError;
+import com.microsoft.azure.kusto.data.exceptions.OneApiError;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.json.JSONArray;
@@ -105,8 +107,11 @@ public class KustoResultSetTable implements ResultSet {
                             String message = exceptions.getString(0);
                             throw new KustoServiceError(message);
                         } else {
-                            throw new KustoServiceError(exceptions);
+                            throw new KustoServiceError(exceptions, false);
                         }
+                    } else {
+                        throw new KustoServiceError(((JSONObject) row).getJSONArray(
+                                "OneApiErrors"),true);
                     }
                 }
                 JSONArray rowAsJsonArray = jsonRows.getJSONArray(i);

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataClientException.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataClientException.java
@@ -3,6 +3,9 @@
 
 package com.microsoft.azure.kusto.data.exceptions;
 
+/*
+  This class represents an error that happened on the client side and is therefore considered permanent
+ */
 public class DataClientException extends Exception {
     private String ingestionSource;
 
@@ -21,5 +24,9 @@ public class DataClientException extends Exception {
     public DataClientException(String ingestionSource, String message, Exception exception) {
         super(message, exception);
         this.ingestionSource = ingestionSource;
+    }
+
+    public Boolean isPermanent(){
+        return true;
     }
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataWebException.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataWebException.java
@@ -9,7 +9,7 @@ import org.json.JSONObject;
 public class DataWebException extends Exception{
 
     private String message;
-    private HttpResponse httpResponse;
+    private final HttpResponse httpResponse;
     private OneApiError apiError;
 
     public String getMessage() { return message; }
@@ -24,22 +24,22 @@ public class DataWebException extends Exception{
 
     public OneApiError getApiError() {
         if (apiError == null) {
-            JSONObject jsonObject = new JSONObject(getMessage());
-            apiError = createApiError(jsonObject);
+            JSONObject jsonObject = new JSONObject(getMessage()).getJSONObject("error");
+            apiError = new OneApiError(
+                    jsonObject.getString("code"),
+                    jsonObject.getString("message"),
+                    jsonObject.getString("@message"),
+                    jsonObject.getString("@type"),
+                    jsonObject.getJSONObject("@context"),
+                    jsonObject.getBoolean("@permanent")
+            );
         }
 
         return apiError;
     }
 
-    static public OneApiError createApiError(JSONObject obj){
-        JSONObject jsonObject = obj.getJSONObject("error");
-        return new OneApiError(
-                jsonObject.getString("code"),
-                jsonObject.getString("message"),
-                jsonObject.getString("@message"),
-                jsonObject.getString("@type"),
-                jsonObject.getJSONObject("@context"),
-                jsonObject.getBoolean("@permanent")
-        );
+    @Override
+    public String toString() {
+        return message;
     }
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataWebException.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataWebException.java
@@ -24,17 +24,22 @@ public class DataWebException extends Exception{
 
     public OneApiError getApiError() {
         if (apiError == null) {
-            JSONObject jsonObject = new JSONObject(getMessage()).getJSONObject("error");
-            apiError = new OneApiError(
-                    jsonObject.getString("code"),
-                    jsonObject.getString("message"),
-                    jsonObject.getString("@message"),
-                    jsonObject.getString("@type"),
-                    jsonObject.getJSONObject("@context"),
-                    jsonObject.getBoolean("@permanent")
-            );
+            JSONObject jsonObject = new JSONObject(getMessage());
+            apiError = createApiError(jsonObject);
         }
 
         return apiError;
+    }
+
+    static public OneApiError createApiError(JSONObject obj){
+        JSONObject jsonObject = obj.getJSONObject("error");
+        return new OneApiError(
+                jsonObject.getString("code"),
+                jsonObject.getString("message"),
+                jsonObject.getString("@message"),
+                jsonObject.getString("@type"),
+                jsonObject.getJSONObject("@context"),
+                jsonObject.getBoolean("@permanent")
+        );
     }
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/KustoServiceError.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/KustoServiceError.java
@@ -12,7 +12,8 @@ import java.util.List;
 public class KustoServiceError extends Exception {
     private ArrayList<Exception> exceptions = null;
 
-    public KustoServiceError(JSONArray exceptions, boolean isOneApi) throws JSONException {
+    public KustoServiceError(JSONArray exceptions, boolean isOneApi, String message) throws JSONException {
+        this(message);
         this.exceptions = new ArrayList<>();
         if (isOneApi){
             for (int j = 0; j < exceptions.length(); j++) {
@@ -31,5 +32,10 @@ public class KustoServiceError extends Exception {
 
     public List<Exception> getExceptions() {
         return exceptions;
+    }
+
+    @Override
+    public String toString() {
+        return "{\"exceptions\":" + exceptions + "}";
     }
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/KustoServiceError.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/KustoServiceError.java
@@ -9,6 +9,9 @@ import org.json.JSONException;
 import java.util.ArrayList;
 import java.util.List;
 
+/*
+  This class represents an error that returned from the service
+ */
 public class KustoServiceError extends Exception {
     private ArrayList<Exception> exceptions = null;
 
@@ -37,5 +40,16 @@ public class KustoServiceError extends Exception {
     @Override
     public String toString() {
         return "{\"exceptions\":" + exceptions + "}";
+    }
+
+    /*
+      Can return null if permanency is not known
+     */
+    public Boolean isPermanent(){
+        if (exceptions != null && exceptions.size() > 0 && exceptions.get(0) instanceof DataWebException) {
+            return ((DataWebException) exceptions.get(0)).getApiError().isPermanent();
+        }
+
+        return null;
     }
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/KustoServiceError.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/KustoServiceError.java
@@ -12,13 +12,19 @@ import java.util.List;
 public class KustoServiceError extends Exception {
     private ArrayList<Exception> exceptions = null;
 
-    public KustoServiceError(JSONArray exceptions) throws JSONException {
+    public KustoServiceError(JSONArray exceptions, boolean isOneApi) throws JSONException {
         this.exceptions = new ArrayList<>();
-        for (int j = 0; j < exceptions.length(); j++) {
-            this.exceptions.add(new Exception(exceptions.getString(j)));
+        if (isOneApi){
+            for (int j = 0; j < exceptions.length(); j++) {
+                this.exceptions.add(new DataWebException(exceptions.getJSONObject(j).toString(), null));
+            }
+        } else {
+            for (int j = 0; j < exceptions.length(); j++) {
+                this.exceptions.add(new Exception(exceptions.getString(j)));
+            }
         }
-
     }
+
     public KustoServiceError(String message) {
         super(message);
     }


### PR DESCRIPTION
Handling OneApiErrors occurring in the middle of rows reading .
Make sure DataServiceError is thrown in case of transient error and reflect this permanency