### PR TITLE
Made url join more robust

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/UriUtils.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/UriUtils.java
@@ -9,6 +9,11 @@ public class UriUtils {
         if (ensureTrailingSlash && !path.endsWith("/")) {
             path += "/";
         }
+        if (!path.startsWith("/"))
+        {
+            path = "/" + path;
+        }
+
         return new URIBuilder(uri).setPath(path).build().toString();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </developers>
 
     <properties>
-        <revision>2.8.0</revision> <!-- CHANGE THIS to adjust project version-->
+        <revision>2.8.1</revision> <!-- CHANGE THIS to adjust project version-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
 


### PR DESCRIPTION
#### Pull Request Description

Makes `setPathForUri` more robust.
In some versions of the JDK,  setPaths will give unwanted results when the path doesn't start with a "/".
Specifically this was observed in the logstash plugin.

This PR also bumps the version to 2.8.1 for fast deployment

---

#### Future Release Comment

**Fixes:**
- Fixes `setPathForUri` for some Java versions
