### PR TITLE
Remove dependency on Java 9/a specific version of a specific project of Java 8

### DIFF
--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionUtils.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionUtils.java
@@ -5,7 +5,6 @@ import com.microsoft.azure.kusto.ingest.source.FileSourceInfo;
 import com.microsoft.azure.kusto.ingest.source.ResultSetSourceInfo;
 import com.microsoft.azure.kusto.ingest.source.StreamSourceInfo;
 import com.univocity.parsers.csv.CsvRoutines;
-
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,7 +19,11 @@ import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 
 public class IngestionUtils {
-    private final static Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private IngestionUtils() {
+        // Hide the default constructor, since this is a utils class
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @NotNull
     public static StreamSourceInfo fileToStream(FileSourceInfo fileSourceInfo, boolean resettable) throws IngestionClientException, FileNotFoundException {
@@ -51,5 +54,17 @@ public class IngestionUtils {
         }
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
         return new StreamSourceInfo(byteArrayInputStream, false, resultSetSourceInfo.getSourceId());
+    }
+
+    public static byte[] readBytesFromInputStream(InputStream value, int testByteArraySize) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        int numBytesRead;
+        byte[] data = new byte[testByteArraySize];
+
+        while ((numBytesRead = value.read(data, 0, data.length)) != -1) {
+            buffer.write(data, 0, numBytesRead);
+        }
+
+        return buffer.toByteArray();
     }
 }

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionUtils.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionUtils.java
@@ -56,13 +56,16 @@ public class IngestionUtils {
         return new StreamSourceInfo(byteArrayInputStream, false, resultSetSourceInfo.getSourceId());
     }
 
-    public static byte[] readBytesFromInputStream(InputStream value, int testByteArraySize) throws IOException {
+    public static byte[] readBytesFromInputStream(InputStream inputStream, int bytesToRead) throws IOException {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         int numBytesRead;
-        byte[] data = new byte[testByteArraySize];
+        int currOffset = 0;
+        byte[] data = new byte[bytesToRead];
 
-        while ((numBytesRead = value.read(data, 0, data.length)) != -1) {
-            buffer.write(data, 0, numBytesRead);
+        while (bytesToRead > 0 && (bytesToRead <= data.length - currOffset) && (numBytesRead = inputStream.read(data, currOffset, bytesToRead)) != -1) {
+            buffer.write(data, currOffset, numBytesRead);
+            currOffset += numBytesRead;
+            bytesToRead -= numBytesRead;
         }
 
         return buffer.toByteArray();

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClient.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClient.java
@@ -27,8 +27,6 @@ import java.lang.invoke.MethodHandles;
 import java.net.URISyntaxException;
 import java.util.UUID;
 
-import sun.misc.IOUtils;
-
 /**
  * <p>ManagedStreamingIngestClient</p>
  * <p>
@@ -168,9 +166,8 @@ public class ManagedStreamingIngestClient implements IngestClient {
         }
 
         byte[] streamingBytes;
-
         try {
-            streamingBytes = IOUtils.readNBytes(streamSourceInfo.getStream(), MAX_STREAMING_SIZE_BYTES + 1);
+            streamingBytes = IngestionUtils.readBytesFromInputStream(streamSourceInfo.getStream(), MAX_STREAMING_SIZE_BYTES + 1);
         } catch (IOException e) {
             throw new IngestionClientException("Failed to read from stream.", e);
         }

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClientTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClientTest.java
@@ -42,8 +42,6 @@ import java.sql.ResultSetMetaData;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import sun.misc.IOUtils;
-
 import static com.microsoft.azure.kusto.ingest.StreamingIngestClientTest.jsonDataUncompressed;
 import static com.microsoft.azure.kusto.ingest.StreamingIngestClientTest.verifyCompressedStreamContent;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -519,7 +517,8 @@ class ManagedStreamingIngestClientTest {
     @ParameterizedTest
     @CsvSource({"true,true", "false,true", "true,false", "false,false"})
     void IngestFromStream_IngestOverFileLimit_QueuedFallback(boolean leaveOpen, boolean useSourceId) throws Exception {
-        byte[] bytes = new byte[5 * 1024 * 1024];
+        int testByteArraySize = 5 * 1024 * 1024;
+        byte[] bytes = new byte[testByteArraySize];
         for (int i = 0; i < bytes.length; i++) {
             bytes[i] = (byte) i;
         }
@@ -540,13 +539,12 @@ class ManagedStreamingIngestClientTest {
 
         InputStream value = capture.getValue();
         if (leaveOpen) {
-            assertArrayEquals(bytes, IOUtils.readAllBytes(value));
+            assertArrayEquals(bytes, IngestionUtils.readBytesFromInputStream(value, testByteArraySize));
         } else {
             assertThrows(IOException.class, () -> {
                 int _ignored = inputStream.read(new byte[1]);
             });
         }
-
     }
 
     @Test

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ResourceManagerTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ResourceManagerTest.java
@@ -52,7 +52,7 @@ class ResourceManagerTest {
     }
 
     @Test
-    void GetIngestionResource_TempStorage_VerifyRoundRubin()
+    void GetIngestionResource_TempStorage_VerifyRoundRobin()
             throws IngestionServiceException, IngestionClientException {
         List<String> availableStorages = new ArrayList<>(Arrays.asList(STORAGE_1, STORAGE_2));
 
@@ -68,7 +68,7 @@ class ResourceManagerTest {
     }
 
     @Test
-    void GetIngestionResource_AggregationQueue_VerifyRoundRubin()
+    void GetIngestionResource_AggregationQueue_VerifyRoundRobin()
             throws IngestionServiceException, IngestionClientException {
         List<String> availableQueues = new ArrayList<>(Arrays.asList(QUEUE_1, QUEUE_2));
 


### PR DESCRIPTION
#### Pull Request Description

Remove dependency on Java 9/a specific version of a specific project of Java 8. sun.misc.IOUtils is a part of OpenJDK, but isn't standard in Java. Further, the method used here was only added about 1 year ago (see https://hg.openjdk.java.net/jdk8u/monojdk8u/rev/8994a5a78287). Strangely, it was added to the Java 8 repo and not the Java 9 repo, but is annotated with `@since 1.9`!

---

#### Future Release Comment
Remove dependency on Java 9/a specific version of a specific project of Java 8. sun.misc.IOUtils is a part of OpenJDK, but isn't standard in Java. Further, the method used here was only added about 1 year ago (see https://hg.openjdk.java.net/jdk8u/monojdk8u/rev/8994a5a78287). Strangely, it was added to the Java 8 repo and not the Java 9 repo, but is annotated with `@since 1.9`!

**Fixes:**
- Remove dependency on Java 9/a specific version of a specific project of Java 8 (sun.misc.IOUtils)
