### PR TITLE
Consider adding an E2E test validating Kusto Service for 1 property

### DIFF
--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
@@ -455,6 +455,31 @@ class E2ETest {
         assertEquals("Two", results);
     }
 
+    @Disabled ("I suggest removing this, as it tests the Kusto service and not this SDK")
+    @Test
+    void testIgnoreFirstRecord() {
+        IngestionProperties ingestionPropertiesWithoutMapping = new IngestionProperties(databaseName, tableName);
+        ingestionPropertiesWithoutMapping.setFlushImmediately(true);
+        ingestionPropertiesWithoutMapping.setDataFormat(DataFormat.CSV);
+        ingestionPropertiesWithoutMapping.setIgnoreFirstRecord(true);
+
+        TestDataItem item = new TestDataItem() {
+            {
+                file = new File(resourcesPath, "dataset.csv");
+                rows = 9; // In fact has 10 rows, but 9 with first ignored
+                ingestionProperties = ingestionPropertiesWithoutMapping;
+            }
+        };
+
+        FileSourceInfo fileSourceInfo = new FileSourceInfo(item.file.getPath(), item.file.length());
+        try {
+            ingestClient.ingestFromFile(fileSourceInfo, item.ingestionProperties);
+        } catch (Exception ex) {
+            Assertions.fail(ex);
+        }
+        assertRowCount(item.rows, false);
+    }
+
     @Test
     void testPerformanceKustoOperationResultVsJsonVsStreamingQuery() throws DataClientException, DataServiceException, IOException {
         ClientRequestProperties clientRequestProperties = new ClientRequestProperties();


### PR DESCRIPTION
Consider adding an E2E test validating Kusto Service for 1 property (IgnoreFirstRecord).

On the **pro** side, Asaf wants to make sure the property we send (IgnoreFirstRecord) is sent properly as expected by the service. This would catch a problem (1) the first time this is implemented, and (2) if the service changes its contract for this property and (3) the service has a bug for this property.

On the **con** side, Yihezkel maintains that since he already added UTs which verify that the Java SDK code sends the property when it should, and since he already manually tested (1) (that this property as sent by the Java SDK is appropriate as expected by the service, and has the expected impact on the service, per https://docs.microsoft.com/azure/data-explorer/ingestion-properties), and since (2) we have control over this external service and have a high level of confidence we won't allow a contract change that break this feature's existing contract, the only remaining purpose for such an E2E test is (3). In other words, such an E2E test fails if and only if there is a bug or contract change in the external service (in this case, the Kusto service). He maintains on principle that such tests should never be included, as responsibility for testing (3) should reside with the service itself. An additional consideration is that retesting this during every build/CI as an E2E is expensive, compounded by the fact that this is just 1 of 13 properties we send to the service.

We will decide whether to enable this E2E test or abandon the PR in a team discussion.