### PR TITLE
Raise visibility of getTableKind

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
@@ -59,6 +59,10 @@ public class KustoResultSetTable {
         return tableId;
     }
 
+    public WellKnownDataSet getTableKind() {
+        return tableKind;
+    }
+    
     public KustoResultColumn[] getColumns() {
         return columnsAsArray;
     }
@@ -69,10 +73,6 @@ public class KustoResultSetTable {
 
     void setTableKind(WellKnownDataSet tableKind) {
         this.tableKind = tableKind;
-    }
-
-    WellKnownDataSet getTableKind() {
-        return tableKind;
     }
 
     protected KustoResultSetTable(JSONObject jsonTable) throws KustoServiceQueryError {


### PR DESCRIPTION
#### Pull Request Description

In case of multiple results - e.g.: `ClientImpl.execute("print 1; print 2")` the `KustoOperationResult.resultTables` will contain two tables with kind `WellKnownDataSet.PrimaryResult`.

While `KustoOperationResult.getPrimaryResults` will always give us the first one, in order for us to retrieve the second one (or more) we need to iterate through all the `KustoOperationResult.resultTables`, and since it contains metadata tables we need to be able to filter it by `WellKnownDataSet` - but we can't since `KustoResultSetTable.getTableKind` is package-private. 

Raising its visibility to public will allow us to achieve what we need - i.e.:
```java
Client client = new ClientImpl(...);
KustoOperationResult operationResult = client.execute("print 1; print 2");
List<KustoResultSetTable> results = operationResult.getResultTables()
        .stream()
        .filter(t -> t.getTableKind().equals(WellKnownDataSet.PrimaryResult))

assert(results.get(0).getInt(0) == 1);
assert(results.get(1).getInt(0) == 2);
```