### PR TITLE
Fix getIntegerObject() return type

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
@@ -309,7 +309,7 @@ public class KustoResultSetTable {
         return (int) get(columnName);
     }
 
-    public int getIntegerObject(String columnName) {
+    public Integer getIntegerObject(String columnName) {
         return getIntegerObject(findColumn(columnName));
     }
 


### PR DESCRIPTION
#### Pull Request Description

Fix KustoResultSetTable.getIntegerObject() return type.

---

#### Future Release Comment

**Fixes:**
- KustoResultSetTable.getIntegerObject() corrected from primitive `int` to `Integer`.
