### PR TITLE
Assure cloud info is only initialized once

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/AccessTokenTokenProvider.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/AccessTokenTokenProvider.java
@@ -3,11 +3,8 @@
 
 package com.microsoft.azure.kusto.data.auth;
 
-import com.microsoft.azure.kusto.data.exceptions.DataClientException;
-import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
-import org.jetbrains.annotations.NotNull;
-
 import java.net.URISyntaxException;
+import org.jetbrains.annotations.NotNull;
 
 public class AccessTokenTokenProvider extends TokenProviderBase {
     private final String accessToken;
@@ -18,7 +15,7 @@ public class AccessTokenTokenProvider extends TokenProviderBase {
     }
 
     @Override
-    public String acquireAccessToken() throws DataServiceException, DataClientException {
+    public String acquireAccessToken() {
         return accessToken;
     }
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/ApplicationCertificateTokenProvider.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/ApplicationCertificateTokenProvider.java
@@ -5,27 +5,29 @@ package com.microsoft.azure.kusto.data.auth;
 
 import com.microsoft.aad.msal4j.ConfidentialClientApplication;
 import com.microsoft.aad.msal4j.IClientCertificate;
-import com.microsoft.azure.kusto.data.exceptions.DataClientException;
-
-import org.jetbrains.annotations.NotNull;
-
+import com.microsoft.aad.msal4j.IConfidentialClientApplication;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import org.jetbrains.annotations.NotNull;
 
 public class ApplicationCertificateTokenProvider extends ConfidentialAppTokenProviderBase {
     private final IClientCertificate clientCertificate;
 
-    ApplicationCertificateTokenProvider(@NotNull String clusterUrl, @NotNull String applicationClientId, @NotNull IClientCertificate clientCertificate, String authorityId) throws URISyntaxException {
+    ApplicationCertificateTokenProvider(
+            @NotNull String clusterUrl,
+            @NotNull String applicationClientId,
+            @NotNull IClientCertificate clientCertificate,
+            String authorityId)
+            throws URISyntaxException {
         super(clusterUrl, applicationClientId, authorityId);
         this.clientCertificate = clientCertificate;
     }
 
     @Override
-    protected void setClientApplicationBasedOnCloudInfo() throws DataClientException {
-        try {
-            clientApplication = ConfidentialClientApplication.builder(applicationClientId, clientCertificate).authority(aadAuthorityUrl).validateAuthority(false).build();
-        } catch (MalformedURLException e) {
-            throw new DataClientException(clusterUrl, ERROR_INVALID_AUTHORITY_URL, e);
-        }
+    protected IConfidentialClientApplication getClientApplication() throws MalformedURLException {
+        return clientApplication = ConfidentialClientApplication.builder(applicationClientId, clientCertificate)
+                .authority(aadAuthorityUrl)
+                .validateAuthority(false)
+                .build();
     }
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/ApplicationCertificateTokenProvider.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/ApplicationCertificateTokenProvider.java
@@ -13,12 +13,7 @@ import org.jetbrains.annotations.NotNull;
 public class ApplicationCertificateTokenProvider extends ConfidentialAppTokenProviderBase {
     private final IClientCertificate clientCertificate;
 
-    ApplicationCertificateTokenProvider(
-            @NotNull String clusterUrl,
-            @NotNull String applicationClientId,
-            @NotNull IClientCertificate clientCertificate,
-            String authorityId)
-            throws URISyntaxException {
+    ApplicationCertificateTokenProvider(@NotNull String clusterUrl, @NotNull String applicationClientId, @NotNull IClientCertificate clientCertificate, String authorityId) throws URISyntaxException {
         super(clusterUrl, applicationClientId, authorityId);
         this.clientCertificate = clientCertificate;
     }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/ApplicationKeyTokenProvider.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/ApplicationKeyTokenProvider.java
@@ -13,12 +13,7 @@ import org.jetbrains.annotations.NotNull;
 public class ApplicationKeyTokenProvider extends ConfidentialAppTokenProviderBase {
     private final IClientSecret clientSecret;
 
-    ApplicationKeyTokenProvider(
-            @NotNull String clusterUrl,
-            @NotNull String applicationClientId,
-            @NotNull IClientSecret clientSecret,
-            String authorityId)
-            throws URISyntaxException {
+    ApplicationKeyTokenProvider(@NotNull String clusterUrl, @NotNull String applicationClientId, @NotNull IClientSecret clientSecret, String authorityId) throws URISyntaxException {
         super(clusterUrl, applicationClientId, authorityId);
         this.clientSecret = clientSecret;
     }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/ApplicationKeyTokenProvider.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/ApplicationKeyTokenProvider.java
@@ -5,27 +5,28 @@ package com.microsoft.azure.kusto.data.auth;
 
 import com.microsoft.aad.msal4j.ConfidentialClientApplication;
 import com.microsoft.aad.msal4j.IClientSecret;
-import com.microsoft.azure.kusto.data.exceptions.DataClientException;
-
-import org.jetbrains.annotations.NotNull;
-
+import com.microsoft.aad.msal4j.IConfidentialClientApplication;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import org.jetbrains.annotations.NotNull;
 
 public class ApplicationKeyTokenProvider extends ConfidentialAppTokenProviderBase {
     private final IClientSecret clientSecret;
 
-    ApplicationKeyTokenProvider(@NotNull String clusterUrl, @NotNull String applicationClientId, @NotNull IClientSecret clientSecret, String authorityId) throws URISyntaxException {
+    ApplicationKeyTokenProvider(
+            @NotNull String clusterUrl,
+            @NotNull String applicationClientId,
+            @NotNull IClientSecret clientSecret,
+            String authorityId)
+            throws URISyntaxException {
         super(clusterUrl, applicationClientId, authorityId);
         this.clientSecret = clientSecret;
     }
 
     @Override
-    protected void setClientApplicationBasedOnCloudInfo() throws DataClientException {
-        try {
-            clientApplication = ConfidentialClientApplication.builder(applicationClientId, clientSecret).authority(aadAuthorityUrl).build();
-        } catch (MalformedURLException e) {
-            throw new DataClientException(clusterUrl, ERROR_INVALID_AUTHORITY_URL, e);
-        }
+    protected IConfidentialClientApplication getClientApplication() throws MalformedURLException {
+        return ConfidentialClientApplication.builder(applicationClientId, clientSecret)
+                .authority(aadAuthorityUrl)
+                .build();
     }
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudDependantTokenProviderBase.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudDependantTokenProviderBase.java
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package com.microsoft.azure.kusto.data.auth;
+
+import com.microsoft.azure.kusto.data.exceptions.DataClientException;
+import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
+
+public abstract class CloudDependantTokenProviderBase extends TokenProviderBase {
+    private static final String ERROR_INVALID_SERVICE_RESOURCE_URL =
+            "Error determining scope due to invalid Kusto Service Resource URL";
+    protected final Set<String> scopes = new HashSet<>();
+    protected CloudInfo cloudInfo = null;
+
+    CloudDependantTokenProviderBase(@NotNull String clusterUrl) throws URISyntaxException {
+        super(clusterUrl);
+    }
+
+    protected void onCloudInfoInitialized() throws DataClientException, DataServiceException {
+        try {
+            scopes.add(cloudInfo.determineScope());
+        } catch (URISyntaxException e) {
+            throw new DataServiceException(clusterUrl, ERROR_INVALID_SERVICE_RESOURCE_URL, e, true);
+        }
+    }
+
+    protected void initializeCloudInfo() throws DataClientException, DataServiceException {
+        if (cloudInfo != null) {
+            return;
+        }
+        synchronized (this) {
+            if (cloudInfo != null) {
+                return;
+            }
+
+            cloudInfo = CloudInfo.retrieveCloudInfoForCluster(clusterUrl);
+            onCloudInfoInitialized();
+        }
+    }
+
+    @Override
+    public String acquireAccessToken() throws DataServiceException, DataClientException {
+        initializeCloudInfo();
+        return acquireAccessTokenAfterCloudInfo();
+    }
+
+    public abstract String acquireAccessTokenAfterCloudInfo() throws DataServiceException, DataClientException;
+}

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudDependentTokenProviderBase.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudDependentTokenProviderBase.java
@@ -40,8 +40,8 @@ public abstract class CloudDependentTokenProviderBase extends TokenProviderBase 
     @Override
     public String acquireAccessToken() throws DataServiceException, DataClientException {
         initialize();
-        return acquireAccessTokenAfterCloudInfo();
+        return acquireAccessTokenImpl();
     }
 
-    public abstract String acquireAccessTokenAfterCloudInfo() throws DataServiceException, DataClientException;
+    protected abstract String acquireAccessTokenImpl() throws DataServiceException, DataClientException;
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
@@ -166,4 +166,13 @@ public class CloudInfo {
     public String getFirstPartyAuthorityUrl() {
         return firstPartyAuthorityUrl;
     }
+
+    public String determineScope() throws URISyntaxException {
+        String resourceUrl = getKustoServiceResourceId();
+        if (isLoginMfaRequired()) {
+            resourceUrl = resourceUrl.replace(".kusto.", ".kustomfa.");
+        }
+
+        return UriUtils.setPathForUri(resourceUrl, ".default");
+    }
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/ConfidentialAppTokenProviderBase.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/ConfidentialAppTokenProviderBase.java
@@ -3,10 +3,12 @@
 
 package com.microsoft.azure.kusto.data.auth;
 
-import com.microsoft.aad.msal4j.*;
+import com.microsoft.aad.msal4j.ClientCredentialParameters;
+import com.microsoft.aad.msal4j.IAccount;
+import com.microsoft.aad.msal4j.IAuthenticationResult;
+import com.microsoft.aad.msal4j.IConfidentialClientApplication;
+import com.microsoft.azure.kusto.data.exceptions.DataClientException;
 import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
-import org.jetbrains.annotations.NotNull;
-
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.util.Set;
@@ -14,10 +16,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.jetbrains.annotations.NotNull;
 
 public abstract class ConfidentialAppTokenProviderBase extends MsalTokenProviderBase {
-    IConfidentialClientApplication clientApplication;
     final String applicationClientId;
+    IConfidentialClientApplication clientApplication;
 
     ConfidentialAppTokenProviderBase(@NotNull String clusterUrl, @NotNull String applicationClientId, String authorityId) throws URISyntaxException {
         super(clusterUrl, authorityId);
@@ -25,10 +28,21 @@ public abstract class ConfidentialAppTokenProviderBase extends MsalTokenProvider
     }
 
     @Override
+    protected void onCloudInfoInitialized() throws DataClientException, DataServiceException {
+        super.onCloudInfoInitialized();
+        try {
+            clientApplication = getClientApplication();
+        } catch (MalformedURLException e) {
+            throw new DataClientException(clusterUrl, ERROR_INVALID_AUTHORITY_URL, e);
+        }
+    }
+
+    @Override
     protected IAuthenticationResult acquireNewAccessToken() throws DataServiceException {
         IAuthenticationResult result;
         try {
-            CompletableFuture<IAuthenticationResult> future = clientApplication.acquireToken(ClientCredentialParameters.builder(scopes).build());
+            CompletableFuture<IAuthenticationResult> future = clientApplication.acquireToken(
+                    ClientCredentialParameters.builder(scopes).build());
             result = future.get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } catch (ExecutionException | TimeoutException e) {
             throw new DataServiceException(clusterUrl, ERROR_ACQUIRING_APPLICATION_ACCESS_TOKEN, e, false);
@@ -38,15 +52,19 @@ public abstract class ConfidentialAppTokenProviderBase extends MsalTokenProvider
         }
 
         if (result == null) {
-            throw new DataServiceException(clusterUrl, "acquireNewAccessToken got 'null' authentication result",
-                    false);
+            throw new DataServiceException(clusterUrl, "acquireNewAccessToken got 'null' authentication result", false);
         }
         return result;
     }
 
     @Override
-    protected IAuthenticationResult acquireAccessTokenSilentlyMsal() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+    protected IAuthenticationResult acquireAccessTokenSilentlyMsal()
+            throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
         CompletableFuture<Set<IAccount>> accounts = clientApplication.getAccounts();
-        return clientApplication.acquireTokenSilently(getSilentParameters(accounts.join())).get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        return clientApplication
+                .acquireTokenSilently(getSilentParameters(accounts.join()))
+                .get(TIMEOUT_MS, TimeUnit.MILLISECONDS);
     }
+
+    protected abstract IConfidentialClientApplication getClientApplication() throws MalformedURLException;
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/ConfidentialAppTokenProviderBase.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/ConfidentialAppTokenProviderBase.java
@@ -28,8 +28,8 @@ public abstract class ConfidentialAppTokenProviderBase extends MsalTokenProvider
     }
 
     @Override
-    protected void onCloudInfoInitialized() throws DataClientException, DataServiceException {
-        super.onCloudInfoInitialized();
+    protected void initializeWithCloudInfo(CloudInfo cloudInfo) throws DataClientException, DataServiceException {
+        super.initializeWithCloudInfo(cloudInfo);
         try {
             clientApplication = getClientApplication();
         } catch (MalformedURLException e) {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/ManagedIdentityTokenProvider.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/ManagedIdentityTokenProvider.java
@@ -4,6 +4,7 @@ import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenRequestContext;
 import com.azure.identity.ManagedIdentityCredential;
 import com.azure.identity.ManagedIdentityCredentialBuilder;
+import com.microsoft.azure.kusto.data.exceptions.DataClientException;
 import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
@@ -23,14 +24,14 @@ public class ManagedIdentityTokenProvider extends TokenProviderBase {
         this.managedIdentityCredential = builder.build();
     }
 
-    private void setRequiredMembersBasedOnCloudInfo() throws DataServiceException {
+    @Override
+    protected void setRequiredMembersBasedOnCloudInfo() throws DataServiceException {
         tokenRequestContext = new TokenRequestContext().addScopes(determineScope());
     }
 
     @Override
-    public String acquireAccessToken() throws DataServiceException {
+    public String acquireAccessToken() throws DataServiceException, DataClientException {
         initializeCloudInfo();
-        setRequiredMembersBasedOnCloudInfo();
         AccessToken accessToken = managedIdentityCredential.getToken(tokenRequestContext).block();
         if (accessToken == null) {
             throw new DataServiceException(clusterUrl, "Couldn't get token from Azure Identity", true);

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/ManagedIdentityTokenProvider.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/ManagedIdentityTokenProvider.java
@@ -31,7 +31,7 @@ public class ManagedIdentityTokenProvider extends CloudDependentTokenProviderBas
     }
 
     @Override
-    public String acquireAccessTokenAfterCloudInfo() throws DataServiceException {
+    public String acquireAccessTokenImpl() throws DataServiceException {
         AccessToken accessToken = managedIdentityCredential.getToken(tokenRequestContext).block();
         if (accessToken == null) {
             throw new DataServiceException(clusterUrl, "Couldn't get token from Azure Identity", true);

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/ManagedIdentityTokenProvider.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/ManagedIdentityTokenProvider.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.net.URISyntaxException;
 
-public class ManagedIdentityTokenProvider extends CloudDependantTokenProviderBase {
+public class ManagedIdentityTokenProvider extends CloudDependentTokenProviderBase {
     private final ManagedIdentityCredential managedIdentityCredential;
     private TokenRequestContext tokenRequestContext;
 
@@ -25,8 +25,8 @@ public class ManagedIdentityTokenProvider extends CloudDependantTokenProviderBas
     }
 
     @Override
-    protected void onCloudInfoInitialized() throws DataServiceException, DataClientException {
-        super.onCloudInfoInitialized();
+    protected void initializeWithCloudInfo(CloudInfo cloudInfo) throws DataServiceException, DataClientException {
+        super.initializeWithCloudInfo(cloudInfo);
         tokenRequestContext = new TokenRequestContext().addScopes(scopes.toArray(new String[0]));
     }
 

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/ManagedIdentityTokenProvider.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/ManagedIdentityTokenProvider.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.net.URISyntaxException;
 
-public class ManagedIdentityTokenProvider extends TokenProviderBase {
+public class ManagedIdentityTokenProvider extends CloudDependantTokenProviderBase {
     private final ManagedIdentityCredential managedIdentityCredential;
     private TokenRequestContext tokenRequestContext;
 
@@ -25,13 +25,13 @@ public class ManagedIdentityTokenProvider extends TokenProviderBase {
     }
 
     @Override
-    protected void setRequiredMembersBasedOnCloudInfo() throws DataServiceException {
-        tokenRequestContext = new TokenRequestContext().addScopes(determineScope());
+    protected void onCloudInfoInitialized() throws DataServiceException, DataClientException {
+        super.onCloudInfoInitialized();
+        tokenRequestContext = new TokenRequestContext().addScopes(scopes.toArray(new String[0]));
     }
 
     @Override
-    public String acquireAccessToken() throws DataServiceException, DataClientException {
-        initializeCloudInfo();
+    public String acquireAccessTokenAfterCloudInfo() throws DataServiceException {
         AccessToken accessToken = managedIdentityCredential.getToken(tokenRequestContext).block();
         if (accessToken == null) {
             throw new DataServiceException(clusterUrl, "Couldn't get token from Azure Identity", true);

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/MsalTokenProviderBase.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/MsalTokenProviderBase.java
@@ -49,7 +49,7 @@ public abstract class MsalTokenProviderBase extends CloudDependentTokenProviderB
 
 
     @Override
-    public String acquireAccessTokenAfterCloudInfo() throws DataServiceException, DataClientException {
+    public String acquireAccessTokenImpl() throws DataServiceException, DataClientException {
         IAuthenticationResult accessTokenResult = acquireAccessTokenSilently();
         if (accessTokenResult == null) {
             accessTokenResult = acquireNewAccessToken();

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/MsalTokenProviderBase.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/MsalTokenProviderBase.java
@@ -31,6 +31,7 @@ public abstract class MsalTokenProviderBase extends TokenProviderBase {
         this.authorityId = authorityId;
     }
 
+    @Override
     protected void setRequiredMembersBasedOnCloudInfo() throws DataClientException, DataServiceException {
         aadAuthorityUrl = determineAadAuthorityUrl();
         scopes.add(determineScope());
@@ -52,7 +53,6 @@ public abstract class MsalTokenProviderBase extends TokenProviderBase {
     @Override
     public String acquireAccessToken() throws DataServiceException, DataClientException {
         initializeCloudInfo();
-        setRequiredMembersBasedOnCloudInfo();
         IAuthenticationResult accessTokenResult = acquireAccessTokenSilently();
         if (accessTokenResult == null) {
             accessTokenResult = acquireNewAccessToken();

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/MsalTokenProviderBase.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/MsalTokenProviderBase.java
@@ -16,12 +16,12 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-public abstract class MsalTokenProviderBase extends TokenProviderBase {
+public abstract class MsalTokenProviderBase extends CloudDependantTokenProviderBase {
+    protected static final String ERROR_ACQUIRING_APPLICATION_ACCESS_TOKEN = "Error acquiring ApplicationAccessToken";
     protected static final String ORGANIZATION_URI_SUFFIX = "organizations";
     protected static final String ERROR_INVALID_AUTHORITY_URL = "Error acquiring ApplicationAccessToken due to invalid Authority URL";
     protected static final int TIMEOUT_MS = 20 * 1000;
     private static final String PERSONAL_TENANT_IDV2_AAD = "9188040d-6c67-4c5b-b112-36a304b66dad"; // Identifies MSA accounts
-    protected final Set<String> scopes = new HashSet<>();
     private final String authorityId;
     protected String aadAuthorityUrl;
 
@@ -32,10 +32,9 @@ public abstract class MsalTokenProviderBase extends TokenProviderBase {
     }
 
     @Override
-    protected void setRequiredMembersBasedOnCloudInfo() throws DataClientException, DataServiceException {
+    protected void onCloudInfoInitialized() throws DataClientException, DataServiceException {
+        super.onCloudInfoInitialized();
         aadAuthorityUrl = determineAadAuthorityUrl();
-        scopes.add(determineScope());
-        setClientApplicationBasedOnCloudInfo();
     }
 
     private String determineAadAuthorityUrl() throws DataClientException {
@@ -48,11 +47,9 @@ public abstract class MsalTokenProviderBase extends TokenProviderBase {
         }
     }
 
-    protected abstract void setClientApplicationBasedOnCloudInfo() throws DataClientException;
 
     @Override
-    public String acquireAccessToken() throws DataServiceException, DataClientException {
-        initializeCloudInfo();
+    public String acquireAccessTokenAfterCloudInfo() throws DataServiceException, DataClientException {
         IAuthenticationResult accessTokenResult = acquireAccessTokenSilently();
         if (accessTokenResult == null) {
             accessTokenResult = acquireNewAccessToken();

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/PublicAppTokenProviderBase.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/PublicAppTokenProviderBase.java
@@ -6,6 +6,7 @@ package com.microsoft.azure.kusto.data.auth;
 import com.microsoft.aad.msal4j.*;
 import com.microsoft.azure.kusto.data.exceptions.DataClientException;
 
+import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
 import org.jetbrains.annotations.NotNull;
 
 import java.net.MalformedURLException;
@@ -23,8 +24,10 @@ public abstract class PublicAppTokenProviderBase extends MsalTokenProviderBase {
         super(clusterUrl, authorityId);
     }
 
+
     @Override
-    protected void setClientApplicationBasedOnCloudInfo() throws DataClientException {
+    protected void onCloudInfoInitialized() throws DataClientException, DataServiceException {
+        super.onCloudInfoInitialized();
         try {
             clientApplication = PublicClientApplication.builder(cloudInfo.getKustoClientAppId()).authority(aadAuthorityUrl).build();
         } catch (MalformedURLException e) {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/PublicAppTokenProviderBase.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/PublicAppTokenProviderBase.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeoutException;
 
 public abstract class PublicAppTokenProviderBase extends MsalTokenProviderBase {
     protected IPublicClientApplication clientApplication;
+    protected String clientAppId;
 
     PublicAppTokenProviderBase(@NotNull String clusterUrl, String authorityId) throws URISyntaxException {
         super(clusterUrl, authorityId);
@@ -26,10 +27,11 @@ public abstract class PublicAppTokenProviderBase extends MsalTokenProviderBase {
 
 
     @Override
-    protected void onCloudInfoInitialized() throws DataClientException, DataServiceException {
-        super.onCloudInfoInitialized();
+    protected void initializeWithCloudInfo(CloudInfo cloudInfo) throws DataClientException, DataServiceException {
+        super.initializeWithCloudInfo(cloudInfo);
         try {
-            clientApplication = PublicClientApplication.builder(cloudInfo.getKustoClientAppId()).authority(aadAuthorityUrl).build();
+            clientAppId = cloudInfo.getKustoClientAppId();
+            clientApplication = PublicClientApplication.builder(clientAppId).authority(aadAuthorityUrl).build();
         } catch (MalformedURLException e) {
             throw new DataClientException(clusterUrl, ERROR_INVALID_AUTHORITY_URL, e);
         }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/SubjectNameIssuerTokenProvider.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/SubjectNameIssuerTokenProvider.java
@@ -2,26 +2,30 @@ package com.microsoft.azure.kusto.data.auth;
 
 import com.microsoft.aad.msal4j.ConfidentialClientApplication;
 import com.microsoft.aad.msal4j.IClientCertificate;
-import com.microsoft.azure.kusto.data.exceptions.DataClientException;
-import org.jetbrains.annotations.NotNull;
-
+import com.microsoft.aad.msal4j.IConfidentialClientApplication;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
+import org.jetbrains.annotations.NotNull;
 
 public class SubjectNameIssuerTokenProvider extends ConfidentialAppTokenProviderBase {
     private final IClientCertificate clientCertificate;
 
-    SubjectNameIssuerTokenProvider(@NotNull String clusterUrl, @NotNull String applicationClientId, @NotNull IClientCertificate clientCertificate, String authorityId) throws URISyntaxException {
+    SubjectNameIssuerTokenProvider(
+            @NotNull String clusterUrl,
+            @NotNull String applicationClientId,
+            @NotNull IClientCertificate clientCertificate,
+            String authorityId)
+            throws URISyntaxException {
         super(clusterUrl, applicationClientId, authorityId);
         this.clientCertificate = clientCertificate;
     }
 
     @Override
-    protected void setClientApplicationBasedOnCloudInfo() throws DataClientException {
-        try {
-            clientApplication = ConfidentialClientApplication.builder(applicationClientId, clientCertificate).authority(aadAuthorityUrl).validateAuthority(false).sendX5c(true).build();
-        } catch (MalformedURLException e) {
-            throw new DataClientException(clusterUrl, ERROR_INVALID_AUTHORITY_URL, e);
-        }
+    protected IConfidentialClientApplication getClientApplication() throws MalformedURLException {
+        return ConfidentialClientApplication.builder(applicationClientId, clientCertificate)
+                .authority(aadAuthorityUrl)
+                .validateAuthority(false)
+                .sendX5c(true)
+                .build();
     }
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/SubjectNameIssuerTokenProvider.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/SubjectNameIssuerTokenProvider.java
@@ -10,12 +10,7 @@ import org.jetbrains.annotations.NotNull;
 public class SubjectNameIssuerTokenProvider extends ConfidentialAppTokenProviderBase {
     private final IClientCertificate clientCertificate;
 
-    SubjectNameIssuerTokenProvider(
-            @NotNull String clusterUrl,
-            @NotNull String applicationClientId,
-            @NotNull IClientCertificate clientCertificate,
-            String authorityId)
-            throws URISyntaxException {
+    SubjectNameIssuerTokenProvider(@NotNull String clusterUrl, @NotNull String applicationClientId, @NotNull IClientCertificate clientCertificate, String authorityId) throws URISyntaxException {
         super(clusterUrl, applicationClientId, authorityId);
         this.clientCertificate = clientCertificate;
     }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/TokenProviderBase.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/TokenProviderBase.java
@@ -3,6 +3,7 @@
 
 package com.microsoft.azure.kusto.data.auth;
 
+import com.azure.core.credential.TokenRequestContext;
 import com.microsoft.azure.kusto.data.UriUtils;
 import com.microsoft.azure.kusto.data.exceptions.DataClientException;
 import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
@@ -24,7 +25,10 @@ public abstract class TokenProviderBase {
         this.clusterUrl = UriUtils.setPathForUri(clusterUrl, "");
     }
 
-    protected void initializeCloudInfo() throws DataServiceException {
+    protected void setRequiredMembersBasedOnCloudInfo() throws DataClientException, DataServiceException {
+    }
+
+    protected void initializeCloudInfo() throws DataClientException, DataServiceException {
         if (cloudInfo != null) {
             return;
         }
@@ -34,6 +38,7 @@ public abstract class TokenProviderBase {
             }
 
             cloudInfo = CloudInfo.retrieveCloudInfoForCluster(clusterUrl);
+            setRequiredMembersBasedOnCloudInfo();
         }
     }
 

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/TokenProviderBase.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/TokenProviderBase.java
@@ -1,60 +1,19 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
-
 package com.microsoft.azure.kusto.data.auth;
 
-import com.azure.core.credential.TokenRequestContext;
 import com.microsoft.azure.kusto.data.UriUtils;
 import com.microsoft.azure.kusto.data.exceptions.DataClientException;
 import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
-
+import java.net.URISyntaxException;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URISyntaxException;
-
 public abstract class TokenProviderBase {
-    protected static final String ERROR_ACQUIRING_APPLICATION_ACCESS_TOKEN = "Error acquiring ApplicationAccessToken";
-    private static final String ERROR_INVALID_SERVICE_RESOURCE_URL = "Error determining scope due to invalid Kusto Service Resource URL";
     protected final Logger logger = LoggerFactory.getLogger(getClass());
     protected final String clusterUrl;
-    protected CloudInfo cloudInfo = null;
 
-    TokenProviderBase(@NotNull String clusterUrl) throws URISyntaxException {
+    public TokenProviderBase(@NotNull String clusterUrl) throws URISyntaxException {
         this.clusterUrl = UriUtils.setPathForUri(clusterUrl, "");
-    }
-
-    protected void setRequiredMembersBasedOnCloudInfo() throws DataClientException, DataServiceException {
-    }
-
-    protected void initializeCloudInfo() throws DataClientException, DataServiceException {
-        if (cloudInfo != null) {
-            return;
-        }
-        synchronized (this) {
-            if (cloudInfo != null) {
-                return;
-            }
-
-            cloudInfo = CloudInfo.retrieveCloudInfoForCluster(clusterUrl);
-            setRequiredMembersBasedOnCloudInfo();
-        }
-    }
-
-    protected String determineScope() throws DataServiceException {
-        String resourceUrl = cloudInfo.getKustoServiceResourceId();
-        if (cloudInfo.isLoginMfaRequired()) {
-            resourceUrl = resourceUrl.replace(".kusto.", ".kustomfa.");
-        }
-
-        String scope;
-        try {
-            scope = UriUtils.setPathForUri(resourceUrl, ".default");
-        } catch (URISyntaxException e) {
-            throw new DataServiceException(clusterUrl, ERROR_INVALID_SERVICE_RESOURCE_URL, e, true);
-        }
-        return scope;
     }
 
     public abstract String acquireAccessToken() throws DataServiceException, DataClientException;

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/UserPromptTokenProvider.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/UserPromptTokenProvider.java
@@ -51,7 +51,7 @@ public class UserPromptTokenProvider extends PublicAppTokenProviderBase {
         IAuthenticationResult result;
         try {
             // This is the only auth method that allows the same application to be used for multiple distinct accounts, so reset account cache between sign-ins
-            clientApplication = PublicClientApplication.builder(cloudInfo.getKustoClientAppId()).authority(aadAuthorityUrl).build();
+            clientApplication = PublicClientApplication.builder(clientAppId).authority(aadAuthorityUrl).build();
             CompletableFuture<IAuthenticationResult> future =
                     clientApplication.acquireToken(InteractiveRequestParameters.builder(redirectUri).scopes(scopes).loginHint(usernameHint).build());
             result = future.get(USER_PROMPT_TIMEOUT_MS, TimeUnit.MILLISECONDS);

--- a/data/src/test/java/com/microsoft/azure/kusto/data/auth/AadAuthenticationHelperTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/auth/AadAuthenticationHelperTest.java
@@ -64,7 +64,7 @@ public class AadAuthenticationHelperTest {
 
         MsalTokenProviderBase aadAuthenticationHelper = (MsalTokenProviderBase) TokenProviderFactory.createTokenProvider(csb);
 
-        aadAuthenticationHelper.initializeCloudInfo();
+        aadAuthenticationHelper.initialize();
         assertEquals("https://login.microsoftonline.com/organizations/", aadAuthenticationHelper.aadAuthorityUrl);
         assertEquals(new HashSet<>(Collections.singletonList("https://kusto.kusto.windows.net/.default")), aadAuthenticationHelper.scopes);
         Assertions.assertThrows(DataServiceException.class,
@@ -158,7 +158,7 @@ public class AadAuthenticationHelperTest {
 
         ));
 
-        aadAuthenticationHelper.initializeCloudInfo();
+        aadAuthenticationHelper.initialize();
         assertEquals("non_standard_client_id", aadAuthenticationHelper.clientApplication.clientId());
         assertEquals("https://nostandard-login-input/weird_auth_id/", aadAuthenticationHelper.clientApplication.authority());
 
@@ -186,7 +186,7 @@ public class AadAuthenticationHelperTest {
         PublicAppTokenProviderBase aadAuthenticationHelper = (PublicAppTokenProviderBase) TokenProviderFactory.createTokenProvider(csb);
         CloudInfo.manuallyAddToCache("https://normal.resource.uri", CloudInfo.DEFAULT_CLOUD);
 
-        aadAuthenticationHelper.initializeCloudInfo();
+        aadAuthenticationHelper.initialize();
         String authorityUrl = CloudInfo.DEFAULT_PUBLIC_LOGIN_URL + "/auth_id/";
         assertEquals(CloudInfo.DEFAULT_KUSTO_CLIENT_APP_ID, aadAuthenticationHelper.clientApplication.clientId());
         assertEquals(authorityUrl, aadAuthenticationHelper.clientApplication.authority());

--- a/data/src/test/java/com/microsoft/azure/kusto/data/auth/AadAuthenticationHelperTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/auth/AadAuthenticationHelperTest.java
@@ -65,7 +65,6 @@ public class AadAuthenticationHelperTest {
         MsalTokenProviderBase aadAuthenticationHelper = (MsalTokenProviderBase) TokenProviderFactory.createTokenProvider(csb);
 
         aadAuthenticationHelper.initializeCloudInfo();
-        aadAuthenticationHelper.setRequiredMembersBasedOnCloudInfo();
         assertEquals("https://login.microsoftonline.com/organizations/", aadAuthenticationHelper.aadAuthorityUrl);
         assertEquals(new HashSet<>(Collections.singletonList("https://kusto.kusto.windows.net/.default")), aadAuthenticationHelper.scopes);
         Assertions.assertThrows(DataServiceException.class,
@@ -160,7 +159,6 @@ public class AadAuthenticationHelperTest {
         ));
 
         aadAuthenticationHelper.initializeCloudInfo();
-        aadAuthenticationHelper.setRequiredMembersBasedOnCloudInfo();
         assertEquals("non_standard_client_id", aadAuthenticationHelper.clientApplication.clientId());
         assertEquals("https://nostandard-login-input/weird_auth_id/", aadAuthenticationHelper.clientApplication.authority());
 
@@ -189,7 +187,6 @@ public class AadAuthenticationHelperTest {
         CloudInfo.manuallyAddToCache("https://normal.resource.uri", CloudInfo.DEFAULT_CLOUD);
 
         aadAuthenticationHelper.initializeCloudInfo();
-        aadAuthenticationHelper.setRequiredMembersBasedOnCloudInfo();
         String authorityUrl = CloudInfo.DEFAULT_PUBLIC_LOGIN_URL + "/auth_id/";
         assertEquals(CloudInfo.DEFAULT_KUSTO_CLIENT_APP_ID, aadAuthenticationHelper.clientApplication.clientId());
         assertEquals(authorityUrl, aadAuthenticationHelper.clientApplication.authority());

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
@@ -219,8 +219,6 @@ class E2ETest {
 
         while (timeoutInSec > 0) {
             try {
-                Thread.sleep(5000);
-                timeoutInSec -= 5;
 
                 if (checkViaJson) {
                     String result = queryClient.executeToJsonResult(databaseName, String.format("%s | count", tableName));
@@ -240,6 +238,10 @@ class E2ETest {
                     mainTableResult.next();
                     actualRowsCount = mainTableResult.getInt(0) - currentCount;
                 }
+
+
+                Thread.sleep(3000);
+                timeoutInSec -= 3;
             } catch (Exception ex) {
                 continue;
             }

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
@@ -214,12 +214,11 @@ class E2ETest {
     }
 
     private void assertRowCount(int expectedRowsCount, boolean checkViaJson) {
-        int timeoutInSec = 100;
+        int totalLoops = 30;
         int actualRowsCount = 0;
 
-        while (timeoutInSec > 0) {
+        for (int i = 0; i < totalLoops; i++) {
             try {
-
                 if (checkViaJson) {
                     String result = queryClient.executeToJsonResult(databaseName, String.format("%s | count", tableName));
                     JSONArray jsonArray = new JSONArray(result);
@@ -239,9 +238,7 @@ class E2ETest {
                     actualRowsCount = mainTableResult.getInt(0) - currentCount;
                 }
 
-
                 Thread.sleep(3000);
-                timeoutInSec -= 3;
             } catch (Exception ex) {
                 continue;
             }

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
@@ -219,6 +219,8 @@ class E2ETest {
 
         for (int i = 0; i < totalLoops; i++) {
             try {
+                Thread.sleep(i * 100);
+
                 if (checkViaJson) {
                     String result = queryClient.executeToJsonResult(databaseName, String.format("%s | count", tableName));
                     JSONArray jsonArray = new JSONArray(result);
@@ -238,7 +240,6 @@ class E2ETest {
                     actualRowsCount = mainTableResult.getInt(0) - currentCount;
                 }
 
-                Thread.sleep(3000);
             } catch (Exception ex) {
                 continue;
             }


### PR DESCRIPTION
A recent changed caused `setRequiredMembersBasedOnCloudInfo` to be called for every query, which meant creating a new token provider, and thus ruined token caching.

Solves #218 

This PR also improves E2E  tests- shorter timer and run after the check for faster tests

