### PR TITLE
Update getKustoDateTime with more lenient formatter

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
@@ -4,7 +4,6 @@
 package com.microsoft.azure.kusto.data;
 
 import com.microsoft.azure.kusto.data.exceptions.KustoServiceQueryError;
-import com.microsoft.azure.kusto.data.format.CslDateTimeFormat;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 import org.json.JSONArray;
@@ -37,6 +36,8 @@ public class KustoResultSetTable {
     private static final String ROWS_PROPERTY_NAME = "Rows";
     private static final String EXCEPTIONS_PROPERTY_NAME = "Exceptions";
     private static final String EXCEPTIONS_MESSAGE = "Query execution failed with multiple inner exceptions";
+    private static DateTimeFormatter kustoDateTimeFormatter = new DateTimeFormatterBuilder().parseCaseInsensitive()
+    .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME).appendLiteral('Z').toFormatter();
 
     private final List<List<Object>> rows;
     private String tableName;
@@ -465,9 +466,7 @@ public class KustoResultSetTable {
             return null;
         }
         String dateString = getString(columnIndex);
-        DateTimeFormatter dateTimeFormatter = new DateTimeFormatterBuilder().parseCaseInsensitive()
-                .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME).appendLiteral('Z').toFormatter();
-        return LocalDateTime.parse(dateString, dateTimeFormatter);
+        return LocalDateTime.parse(dateString, kustoDateTimeFormatter);
     }
 
     public LocalDateTime getKustoDateTime(String columnName) {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
@@ -465,15 +465,9 @@ public class KustoResultSetTable {
             return null;
         }
         String dateString = getString(columnIndex);
-        DateTimeFormatter dateTimeFormatter;
-        if (dateString.length() < 21) {
-            dateTimeFormatter = new DateTimeFormatterBuilder().parseCaseInsensitive()
-                    .append(DateTimeFormatter.ofPattern(CslDateTimeFormat.KUSTO_DATETIME_PATTERN_NO_FRACTIONS)).toFormatter();
-        } else {
-            dateTimeFormatter = new DateTimeFormatterBuilder().parseCaseInsensitive()
-                    .append(DateTimeFormatter.ofPattern(CslDateTimeFormat.KUSTO_DATETIME_PATTERN)).toFormatter();
-        }
-        return LocalDateTime.parse(getString(columnIndex), dateTimeFormatter);
+        DateTimeFormatter dateTimeFormatter = new DateTimeFormatterBuilder().parseCaseInsensitive()
+                .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME).appendLiteral('Z').toFormatter();
+        return LocalDateTime.parse(dateString, dateTimeFormatter);
     }
 
     public LocalDateTime getKustoDateTime(String columnName) {

--- a/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
@@ -1,0 +1,61 @@
+package com.microsoft.azure.kusto.data;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+public class KustoDateTimeTest {
+    @Test
+    void KustoResultSet() throws Exception {
+        JSONArray rows = new JSONArray();
+        JSONArray row = new JSONArray();
+        row.put(Instant.parse("2022-05-17T00:00:00Z"));
+        rows.put(row);
+        row = new JSONArray();
+        row.put(Instant.parse("2022-05-17T00:00:00.1Z"));
+        rows.put(row);
+        row = new JSONArray();
+        row.put(Instant.parse("2022-05-17T00:00:00.12Z"));
+        rows.put(row);
+        row = new JSONArray();
+        row.put(Instant.parse("2022-05-17T00:00:00.123Z"));
+        rows.put(row);
+        row = new JSONArray();
+        row.put(Instant.parse("2022-05-17T00:00:00.1234Z"));
+        rows.put(row);
+        row = new JSONArray();
+        row.put(Instant.parse("2022-05-17T00:00:00.12345Z"));
+        rows.put(row);
+        row = new JSONArray();
+        row.put(Instant.parse("2022-05-17T00:00:00.123456Z"));
+        rows.put(row);
+        row = new JSONArray();
+        row.put(Instant.parse("2022-05-17T00:00:00.1234567Z"));
+        rows.put(row);
+        row = new JSONArray();
+        row.put(Instant.parse("2022-05-17T00:00:00.12345678Z"));
+        rows.put(row);
+        row = new JSONArray();
+        row.put(Instant.parse("2022-05-17T00:00:00.123456789Z"));
+        rows.put(row);
+
+        String columns = "[ { \"ColumnName\": \"a\", \"ColumnType\": \"datetime\" } ]";
+        KustoResultSetTable res = new KustoResultSetTable(new JSONObject("{\"TableName\":\"Table_0\"," +
+                "\"Columns\":" + columns + ",\"Rows\":" +
+                rows.toString() + "}"));
+
+        Integer rowNum = 0;                
+        while (res.next())
+        {
+            Assertions.assertEquals(
+                LocalDateTime.ofInstant((Instant)((JSONArray)rows.get(rowNum)).get(0), ZoneOffset.UTC), 
+                res.getKustoDateTime(0));
+            rowNum++;
+        }
+    }
+}

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
@@ -12,8 +12,10 @@ import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -75,6 +77,7 @@ public class ResultSetTest {
         assert res.getBooleanObject(0) == null;
         assert res.getString(1).equals("");
         assert res.getTimestamp(2) == null;
+        assert res.getKustoDateTime(2) == null;
         assert res.getBigDecimal(3) == null;
         assert res.getJSONObject(4) == null;
         assert res.getUUID(5) == null;
@@ -88,6 +91,7 @@ public class ResultSetTest {
         Assertions.assertTrue(res.getBooleanObject(0));
         Assertions.assertEquals(res.getString(1), str);
         Assertions.assertEquals(res.getTimestamp(2), Timestamp.valueOf(now.atZone(ZoneId.of("UTC")).toLocalDateTime()));
+        Assertions.assertEquals(LocalDateTime.ofInstant(now, ZoneOffset.UTC), res.getKustoDateTime(2));
         SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
         Assertions.assertEquals(sdf.format(new Date(now.getEpochSecond() * 1000)), res.getDate(2).toString());


### PR DESCRIPTION
#### Pull Request Description

The `getKustoDateTime` function uses 2 potential formatters for the LocalDateTime that either include no digits for the fraction of a second or 7 digits for the fraction of a second. We ran into a situation where the value coming back from ADX had a different number of digits and would cause this method to fail. This code updates that function to just use the built-in `ISO_LOCAL_DATE_TIME` formatter, which allows for 0-9 digits in the fraction of a second, and appends the literal 'Z' to the end of the formatter to account for that value being present in the datetimes that ADX sends back.

---

#### Future Release Comment
Updating the `getKustoDateTime` function to use the built-in `ISO_LOCAL_DATE_TIME` formatter, which allows for 0-9 digits in the fraction of a second, and append the literal 'Z' to the end of the formatter to account for that value being present in the datetimes that ADX sends back.

**Breaking Changes:**
- None

**Features:**
- None

**Fixes:**
- Use a more lenient LocalDateTime formatter for parsing in `getKustoDateTime`
