### PR TITLE
Fix localhost handling

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
@@ -253,7 +253,7 @@ class Utils {
     private static URI parseUriFromUrlString(String url) throws DataClientException {
         try {
             URL cleanUrl = new URL(url);
-            if ("https".equalsIgnoreCase(cleanUrl.getProtocol()) || cleanUrl.getHost().equalsIgnoreCase(CloudInfo.LOCALHOST)) {
+            if ("https".equalsIgnoreCase(cleanUrl.getProtocol()) || url.toLowerCase().startsWith(CloudInfo.LOCALHOST)) {
                 return new URI(cleanUrl.getProtocol(), cleanUrl.getUserInfo(), cleanUrl.getHost(), cleanUrl.getPort(), cleanUrl.getPath(), cleanUrl.getQuery(),
                         cleanUrl.getRef());
             } else {


### PR DESCRIPTION
#### Pull Request Description

[This PR](https://github.com/Azure/azure-kusto-java/pull/185/) added support for localhost in the Kusto client. This is extremely useful to mock ADX using Wiremock for example.

There seems to be one last issue however in `com.microsoft.azure.kusto.data.Utils.parseUriFromUrlString`. A typical input `url` would be `http://localhost:[port]/v2/rest/query`; however, when parsed, the `cleanUrl` host is `localhost` and not `http://localhost`.

The fix in this PR is to use the exact same logic as the ClientImpl constructor which is:

```java
aadAuthenticationHelper = clusterUrl.toLowerCase().startsWith(CloudInfo.LOCALHOST) ? null : TokenProviderFactory.createTokenProvider(csb, httpClient);
```

---

#### Future Release Comment

Full support of localhost in Kusto Data to effectively be able to mock ADX APIs.
