### PR TITLE
Send sourceMessageCreationTime, which can help troubleshoot delays

### DIFF
--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionBlobInfo.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionBlobInfo.java
@@ -6,6 +6,10 @@ package com.microsoft.azure.kusto.ingest;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.microsoft.azure.kusto.ingest.result.IngestionStatusInTableDescription;
 import com.microsoft.azure.kusto.ingest.result.ValidationPolicy;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.UUID;
 
@@ -18,8 +22,10 @@ public final class IngestionBlobInfo {
     private final Boolean retainBlobOnSuccess;
     private String reportLevel;
     private String reportMethod;
+    private String sourceMessageCreationTime;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL) private ValidationPolicy validationPolicy;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private ValidationPolicy validationPolicy;
 
     private Boolean flushImmediately;
     private IngestionStatusInTableDescription ingestionStatusInTable;
@@ -34,6 +40,7 @@ public final class IngestionBlobInfo {
         reportLevel = IngestionProperties.IngestionReportLevel.FAILURES_ONLY.getKustoValue();
         reportMethod = IngestionProperties.IngestionReportMethod.QUEUE.getKustoValue();
         flushImmediately = false;
+        sourceMessageCreationTime = LocalDateTime.ofInstant(Instant.now(), ZoneId.of("UTC")).toString();
     }
 
     public String getBlobPath() {
@@ -82,6 +89,14 @@ public final class IngestionBlobInfo {
 
     public void setReportMethod(String reportMethod) {
         this.reportMethod = reportMethod;
+    }
+
+    public String getSourceMessageCreationTime() {
+        return sourceMessageCreationTime;
+    }
+
+    public void setSourceMessageCreationTime(String sourceMessageCreationTime) {
+        this.sourceMessageCreationTime = sourceMessageCreationTime;
     }
 
     public Boolean getFlushImmediately() {

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionBlobInfo.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionBlobInfo.java
@@ -24,8 +24,7 @@ public final class IngestionBlobInfo {
     private String reportMethod;
     private String sourceMessageCreationTime;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private ValidationPolicy validationPolicy;
+    @JsonInclude(JsonInclude.Include.NON_NULL) private ValidationPolicy validationPolicy;
 
     private Boolean flushImmediately;
     private IngestionStatusInTableDescription ingestionStatusInTable;

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -33,7 +33,7 @@
     </developers>
 
     <properties>
-        <revision>3.1.1</revision> <!-- CHANGE THIS to match project version in the root (not technically parent) pom -->
+        <revision>3.1.2</revision> <!-- CHANGE THIS to match project version in the root (not technically parent) pom -->
         <java.version>1.8</java.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>


### PR DESCRIPTION
It's already included in the C# SDK for the same reason.

#### Pull Request Description

Send sourceMessageCreationTime, which can help troubleshoot delays

---

#### Future Release Comment
**Features:**
- Send sourceMessageCreationTime