### PR TITLE
Black: Roll back requiring there be no newline after a field's annotation

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/WebException.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/WebException.java
@@ -4,7 +4,8 @@ import org.apache.http.HttpResponse;
 import org.jetbrains.annotations.Nullable;
 
 public class WebException extends Exception {
-    @Nullable protected final HttpResponse httpResponse;
+    @Nullable
+    protected final HttpResponse httpResponse;
 
     public WebException(String message, @Nullable HttpResponse httpResponse, Throwable cause) {
         super(message, cause);

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/AzureStorageClient.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/AzureStorageClient.java
@@ -37,7 +37,8 @@ class AzureStorageClient {
     private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final int GZIP_BUFFER_SIZE = 16384;
     private static final int STREAM_BUFFER_SIZE = 16384;
-    @Nullable private final OperationContext operationContext;
+    @Nullable
+    private final OperationContext operationContext;
 
     public AzureStorageClient() {
         this(null);

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionBlobInfo.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionBlobInfo.java
@@ -24,7 +24,8 @@ public final class IngestionBlobInfo {
     private String reportMethod;
     private String sourceMessageCreationTime;
 
-    @JsonInclude(JsonInclude.Include.NON_NULL) private ValidationPolicy validationPolicy;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private ValidationPolicy validationPolicy;
 
     private Boolean flushImmediately;
     private IngestionStatusInTableDescription ingestionStatusInTable;

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClientTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClientTest.java
@@ -71,10 +71,13 @@ class ManagedStreamingIngestClientTest {
     private static IngestionProperties ingestionProperties;
     private static final String STORAGE_URL = "https://testcontosourl.com/storageUrl";
 
-    @Mock private static StreamingClient streamingClientMock;
+    @Mock
+    private static StreamingClient streamingClientMock;
 
-    @Captor private static ArgumentCaptor<InputStream> argumentCaptor;
-    @Captor private static ArgumentCaptor<ClientRequestProperties> clientRequestPropertiesCaptor;
+    @Captor
+    private static ArgumentCaptor<InputStream> argumentCaptor;
+    @Captor
+    private static ArgumentCaptor<ClientRequestProperties> clientRequestPropertiesCaptor;
 
     private static final UUID CustomUUID = UUID.fromString("11111111-1111-1111-1111-111111111111");
 

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/StreamingIngestClientTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/StreamingIngestClientTest.java
@@ -64,9 +64,11 @@ class StreamingIngestClientTest {
     private static StreamingIngestClient streamingIngestClient;
     private IngestionProperties ingestionProperties;
 
-    @Mock private static StreamingClient streamingClientMock;
+    @Mock
+    private static StreamingClient streamingClientMock;
 
-    @Captor private static ArgumentCaptor<InputStream> argumentCaptor;
+    @Captor
+    private static ArgumentCaptor<InputStream> argumentCaptor;
 
     private static final String ENDPOINT_SERVICE_TYPE_DM = "DataManagement";
     private String resourcesDirectory = System.getProperty("user.dir") + "/src/test/resources/";

--- a/kusto-style.xml
+++ b/kusto-style.xml
@@ -225,7 +225,6 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_case" value="insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>

--- a/quickstart/kusto-style.xml
+++ b/quickstart/kusto-style.xml
@@ -225,7 +225,6 @@
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_arrow_in_switch_case" value="insert"/>
-        <setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
         <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>


### PR DESCRIPTION
#### Pull Request Description

Black: Roll back requiring there be no newline after a field's annotation. Alternatively, require that there *be* a newline after a field's annotation.

As discussed previously, my perspective is that if one code style isn't clearly better than alternatives, the best approach is to let the devs decide. We don't need all aspects of code style to be 100% conforming in all ways, and taking away freedom unnecessarily from devs makes devs sad.

---

#### Future Release Comment
**Fixes:**
- Roll back requiring there be no newline after a field's annotation