### PR TITLE
Added keep alive header

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
@@ -267,6 +267,8 @@ public class ClientImpl implements Client, StreamingClient {
         }
         headers.put("x-ms-client-request-id", clientRequestId);
 
+        headers.put("Connection", "Keep-Alive");
+
         UUID activityId = UUID.randomUUID();
         String activityContext = String.format("%s%s/%s, ActivityId=%s, ParentId=%s, ClientRequestId=%s", JAVA_INGEST_ACTIVITY_TYPE_PREFIX, activityTypeSuffix,
                 activityId, activityId, activityId, clientRequestId);


### PR DESCRIPTION
Other SDKs have this header, and it prevents the server from disconnecting us mid-query.

The settings we already have that control the keep-alive know how to work with this header too.