### PR TITLE
Automatic conversion of query/ingestion urls in ingest clients

### DIFF
--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientBase.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientBase.java
@@ -11,68 +11,31 @@ import java.lang.invoke.MethodHandles;
 import java.net.URISyntaxException;
 
 public abstract class IngestClientBase {
+    static final String INGEST_PREFIX = "://ingest-";
+    static final String NO_INGEST_PREFIX = "://";
+
     private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     String connectionDataSource;
-    private String endpointServiceType;
-    private String suggestedEndpointUri;
-    public static final String INGEST_PREFIX = "ingest-";
     protected static final String WRONG_ENDPOINT_MESSAGE = "Ingestion failed likely because the wrong endpoint, whose ServiceType %s, was configured, which isn't compatible with the client of type '%s' being used. Initialize the client with the appropriate endpoint URL";
-    protected static final String CONFIGURED_ENDPOINT_MESSAGE = "is '%s'";
-    protected static final String INDETERMINATE_CONFIGURED_ENDPOINT_MESSAGE = "couldn't be determined";
-
-    protected void validateEndpointServiceType(String endpoint, String expectedServiceType)
-            throws IngestionClientException {
-        if (StringUtils.isBlank(endpointServiceType)) {
-            endpointServiceType = retrieveServiceType();
-        }
-        if (!expectedServiceType.equals(endpointServiceType)) {
-            String message;
-            if (StringUtils.isNotBlank(endpointServiceType)) {
-                String configuredEndpointMessage = String.format(CONFIGURED_ENDPOINT_MESSAGE, endpointServiceType);
-                message = String.format(WRONG_ENDPOINT_MESSAGE, configuredEndpointMessage, expectedServiceType);
-            } else {
-                message = String.format(WRONG_ENDPOINT_MESSAGE, INDETERMINATE_CONFIGURED_ENDPOINT_MESSAGE, expectedServiceType);
-            }
-            suggestedEndpointUri = generateEndpointSuggestion(suggestedEndpointUri, endpoint);
-            if (StringUtils.isNotBlank(suggestedEndpointUri)) {
-                message = String.format("%s, which is likely '%s'.", message, suggestedEndpointUri);
-            } else {
-                message += ".";
-            }
-            throw new IngestionClientException(message);
-        }
-    }
-
-    protected String generateEndpointSuggestion(String existingSuggestedEndpointUri, String dataSource) {
-        if (existingSuggestedEndpointUri != null) {
-            return existingSuggestedEndpointUri;
-        }
-        // The default is not passing a suggestion to the exception
-        String endpointUriToSuggestStr = "";
-        if (StringUtils.isNotBlank(dataSource)) {
-            URIBuilder existingEndpoint;
-            try {
-                existingEndpoint = new URIBuilder(dataSource);
-                endpointUriToSuggestStr = emendEndpointUri(existingEndpoint);
-            } catch (URISyntaxException e) {
-                log.warn(
-                        "Since the wrong endpoint was used, we attempted to suggest the correct endpoint. However, we couldn't parse dataSource '{}', so no suggestion can be made.",
-                        dataSource, e);
-            } catch (IllegalArgumentException e) {
-                log.warn(
-                        "Since the wrong endpoint was used, we attempted to suggest the correct endpoint. However, the URL is already in the correct format '{}', so no suggestion can be made.",
-                        dataSource, e);
-            }
-        }
-
-        return endpointUriToSuggestStr;
-    }
-
-    protected abstract String retrieveServiceType();
-
-    protected abstract String emendEndpointUri(URIBuilder existingEndpoint);
 
     static boolean shouldCompress(CompressionType sourceCompressionType, IngestionProperties.DataFormat dataFormat) {
         return (sourceCompressionType == null) && (dataFormat == null || dataFormat.isCompressible());
     }
+
+    static String getIngestionEndpoint(String clusterUrl) {
+        if (clusterUrl.contains(INGEST_PREFIX)) {
+            return clusterUrl;
+        } else {
+            return clusterUrl.replace(NO_INGEST_PREFIX, INGEST_PREFIX);
+        }
+    }
+
+    static String getQueryEndpoint(String clusterUrl) {
+        if (clusterUrl.contains(INGEST_PREFIX)) {
+            return clusterUrl.replace(INGEST_PREFIX, NO_INGEST_PREFIX);
+        } else {
+            return clusterUrl;
+        }
+    }
+
 }

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientBase.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientBase.java
@@ -1,22 +1,12 @@
 package com.microsoft.azure.kusto.ingest;
 
-import com.microsoft.azure.kusto.ingest.exceptions.IngestionClientException;
 import com.microsoft.azure.kusto.ingest.source.CompressionType;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.utils.URIBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.lang.invoke.MethodHandles;
-import java.net.URISyntaxException;
 
 public abstract class IngestClientBase {
-    static final String INGEST_PREFIX = "://ingest-";
-    static final String NO_INGEST_PREFIX = "://";
+    static final String INGEST_PREFIX = "ingest-";
+    static final String PROTOCOL_SUFFIX = "://";
 
-    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     String connectionDataSource;
-    protected static final String WRONG_ENDPOINT_MESSAGE = "Ingestion failed likely because the wrong endpoint, whose ServiceType %s, was configured, which isn't compatible with the client of type '%s' being used. Initialize the client with the appropriate endpoint URL";
 
     static boolean shouldCompress(CompressionType sourceCompressionType, IngestionProperties.DataFormat dataFormat) {
         return (sourceCompressionType == null) && (dataFormat == null || dataFormat.isCompressible());
@@ -26,13 +16,13 @@ public abstract class IngestClientBase {
         if (clusterUrl.contains(INGEST_PREFIX)) {
             return clusterUrl;
         } else {
-            return clusterUrl.replace(NO_INGEST_PREFIX, INGEST_PREFIX);
+            return clusterUrl.replaceFirst(PROTOCOL_SUFFIX, PROTOCOL_SUFFIX + INGEST_PREFIX);
         }
     }
 
     static String getQueryEndpoint(String clusterUrl) {
         if (clusterUrl.contains(INGEST_PREFIX)) {
-            return clusterUrl.replace(INGEST_PREFIX, NO_INGEST_PREFIX);
+            return clusterUrl.replaceFirst(INGEST_PREFIX, "");
         } else {
             return clusterUrl;
         }

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientFactory.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientFactory.java
@@ -60,32 +60,62 @@ public class IngestClientFactory {
 
     /**
      * Creates a new managed streaming ingest client, with default http client properties.
-     * @param dmConnectionStringBuilder connection string builder for the data management endpoint
-     * @param engineConnectionStringBuilder connection string builder for the engine endpoint
+     * This method should only be used for advanced cases. If your endpoints are standard, or you do not know, use {@link #createManagedStreamingIngestClient(ConnectionStringBuilder)} instead.
+     * @param ingestionEndpointConnectionStringBuilder connection string builder for the data management endpoint
+     * @param queryEndpointConnectionStringBuilder connection string builder for the engine endpoint
      * @return a new managed streaming ingest client
      * @throws URISyntaxException if the connection string is invalid
      */
-    public static ManagedStreamingIngestClient createManagedStreamingIngestClient(ConnectionStringBuilder dmConnectionStringBuilder,
-            ConnectionStringBuilder engineConnectionStringBuilder)
+    public static ManagedStreamingIngestClient createManagedStreamingIngestClient(ConnectionStringBuilder ingestionEndpointConnectionStringBuilder,
+            ConnectionStringBuilder queryEndpointConnectionStringBuilder)
             throws URISyntaxException {
-        return createManagedStreamingIngestClient(dmConnectionStringBuilder, engineConnectionStringBuilder, null);
+        return createManagedStreamingIngestClient(ingestionEndpointConnectionStringBuilder, queryEndpointConnectionStringBuilder, null);
     }
 
     /**
      * Creates a new managed streaming ingest client.
-     * @param dmConnectionStringBuilder connection string builder for the data management endpoint
-     * @param engineConnectionStringBuilder connection string builder for the engine endpoint
+     * This method should only be used for advanced cases. If your endpoints are standard, or you do not know, use
+     * {@link #createManagedStreamingIngestClient(ConnectionStringBuilder, HttpClientProperties)} instead.
+     * @param ingestionEndpointConnectionStringBuilder connection string builder for the data management endpoint
+     * @param queryEndpointConnectionStringBuilder connection string builder for the engine endpoint
      * @param properties additional properties to configure the http client
      * @return a new managed streaming ingest client
      * @throws URISyntaxException if the connection string is invalid
      */
-    public static ManagedStreamingIngestClient createManagedStreamingIngestClient(ConnectionStringBuilder dmConnectionStringBuilder,
-            ConnectionStringBuilder engineConnectionStringBuilder, @Nullable HttpClientProperties properties)
+    public static ManagedStreamingIngestClient createManagedStreamingIngestClient(ConnectionStringBuilder ingestionEndpointConnectionStringBuilder,
+            ConnectionStringBuilder queryEndpointConnectionStringBuilder, @Nullable HttpClientProperties properties)
             throws URISyntaxException {
-        return new ManagedStreamingIngestClient(dmConnectionStringBuilder, engineConnectionStringBuilder, properties);
+        return new ManagedStreamingIngestClient(ingestionEndpointConnectionStringBuilder, queryEndpointConnectionStringBuilder, properties);
     }
 
     /**
+     * Creates a new managed streaming ingest client, with default http client properties.
+     * This method supports both an ingestion and query endpoint, and deduces the other endpoint from the given one.
+     * @param connectionStringBuilder connection string builder for the client
+     * @return a new managed streaming ingest client
+     * @throws URISyntaxException if the connection string is invalid
+     */
+    public static ManagedStreamingIngestClient createManagedStreamingIngestClient(ConnectionStringBuilder connectionStringBuilder)
+            throws URISyntaxException {
+        return createManagedStreamingIngestClient(connectionStringBuilder, (HttpClientProperties) null);
+    }
+
+    /**
+     * Creates a new managed streaming ingest client.
+     * This method supports both an ingestion and query endpoint, and deduces the other endpoint from the given one.
+     * @param connectionStringBuilder connection string builder for the client
+     * @param properties additional properties to configure the http client
+     * @return a new managed streaming ingest client
+     * @throws URISyntaxException if the connection string is invalid
+     */
+    public static ManagedStreamingIngestClient createManagedStreamingIngestClient(ConnectionStringBuilder connectionStringBuilder,
+            @Nullable HttpClientProperties properties)
+            throws URISyntaxException {
+        return new ManagedStreamingIngestClient(connectionStringBuilder, properties);
+    }
+
+    /**
+     * @deprecated - Ingest clients now automatically deduce the endpoint, use {@link #createManagedStreamingIngestClient(ConnectionStringBuilder)} instead.
      * Creates a new ManagedStreamingIngestClient from an engine connection string, with default http client properties.
      * This method infers the DM connection string from the engine connection string.
      * For advanced usage, use {@link ManagedStreamingIngestClient#ManagedStreamingIngestClient(ConnectionStringBuilder, ConnectionStringBuilder)}
@@ -99,6 +129,7 @@ public class IngestClientFactory {
     }
 
     /**
+     * @deprecated - Ingest clients now automatically deduce the endpoint, use {@link #createManagedStreamingIngestClient(ConnectionStringBuilder, HttpClientProperties)} instead.
      * Creates a new ManagedStreamingIngestClient from an engine connection string.
      * This method infers the DM connection string from the engine connection string.
      * For advanced usage, use {@link ManagedStreamingIngestClient#ManagedStreamingIngestClient(ConnectionStringBuilder, ConnectionStringBuilder)}
@@ -114,6 +145,7 @@ public class IngestClientFactory {
     }
 
     /**
+     * @deprecated - Ingest clients now automatically deduce the endpoint, use {@link #createManagedStreamingIngestClient(ConnectionStringBuilder)} instead.
      * Creates a new ManagedStreamingIngestClient from a DM connection string, with default http client properties.
      * This method infers the engine connection string from the DM connection string.
      * For advanced usage, use {@link ManagedStreamingIngestClient#ManagedStreamingIngestClient(ConnectionStringBuilder, ConnectionStringBuilder)}
@@ -127,6 +159,7 @@ public class IngestClientFactory {
     }
 
     /**
+     * @deprecated - Ingest clients now automatically deduce the endpoint, use {@link #createManagedStreamingIngestClient(ConnectionStringBuilder, HttpClientProperties)} instead.
      * Creates a new ManagedStreamingIngestClient from a DM connection string.
      * This method infers the engine connection string from the DM connection string.
      * For advanced usage, use {@link ManagedStreamingIngestClient#ManagedStreamingIngestClient(ConnectionStringBuilder, ConnectionStringBuilder)}

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClient.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClient.java
@@ -50,6 +50,7 @@ public class ManagedStreamingIngestClient implements IngestClient {
     private final ExponentialRetry exponentialRetryTemplate;
 
     /**
+     * @deprecated - Ingest clients now automatically deduce the endpoint, use {@link #ManagedStreamingIngestClient(ConnectionStringBuilder, HttpClientProperties)} instead.
      * Creates a new ManagedStreamingIngestClient from a DM connection string, with default http client properties.
      * This method infers the engine connection string from the DM connection string.
      * For advanced usage, use {@link ManagedStreamingIngestClient#ManagedStreamingIngestClient(ConnectionStringBuilder, ConnectionStringBuilder)}
@@ -62,6 +63,7 @@ public class ManagedStreamingIngestClient implements IngestClient {
     }
 
     /**
+     * @deprecated - Ingest clients now automatically deduce the endpoint, use {@link #ManagedStreamingIngestClient(ConnectionStringBuilder, HttpClientProperties)} instead.
      * Creates a new ManagedStreamingIngestClient from a DM connection string.
      * This method infers the engine connection string from the DM connection string.
      * For advanced usage, use {@link ManagedStreamingIngestClient#ManagedStreamingIngestClient(ConnectionStringBuilder, ConnectionStringBuilder)}
@@ -74,11 +76,12 @@ public class ManagedStreamingIngestClient implements IngestClient {
             @Nullable HttpClientProperties properties)
             throws URISyntaxException {
         ConnectionStringBuilder engineConnectionString = new ConnectionStringBuilder(dmConnectionString);
-        engineConnectionString.setClusterUrl(StreamingIngestClient.generateEngineUriSuggestion(new URIBuilder(dmConnectionString.getClusterUrl())));
+        engineConnectionString.setClusterUrl(IngestClientBase.getQueryEndpoint(engineConnectionString.getClusterUrl()));
         return new ManagedStreamingIngestClient(dmConnectionString, engineConnectionString, properties);
     }
 
     /**
+     * @deprecated - Ingest clients now automatically deduce the endpoint, use {@link #ManagedStreamingIngestClient(ConnectionStringBuilder, HttpClientProperties)} instead.
      * Creates a new ManagedStreamingIngestClient from an engine connection string, with default http client properties.
      * This method infers the DM connection string from the engine connection string.
      * For advanced usage, use {@link ManagedStreamingIngestClient#ManagedStreamingIngestClient(ConnectionStringBuilder, ConnectionStringBuilder)}
@@ -91,6 +94,7 @@ public class ManagedStreamingIngestClient implements IngestClient {
     }
 
     /**
+     * @deprecated - Ingest clients now automatically deduce the endpoint, use {@link #ManagedStreamingIngestClient(ConnectionStringBuilder, HttpClientProperties)} instead.
      * Creates a new ManagedStreamingIngestClient from an engine connection string.
      * This method infers the DM connection string from the engine connection string.
      * For advanced usage, use {@link ManagedStreamingIngestClient#ManagedStreamingIngestClient(ConnectionStringBuilder, ConnectionStringBuilder)}
@@ -103,24 +107,51 @@ public class ManagedStreamingIngestClient implements IngestClient {
             @Nullable HttpClientProperties properties)
             throws URISyntaxException {
         ConnectionStringBuilder dmConnectionString = new ConnectionStringBuilder(engineConnectionString);
-        dmConnectionString.setClusterUrl(QueuedIngestClientImpl.generateDmUriSuggestion(new URIBuilder(engineConnectionString.getClusterUrl())));
+        dmConnectionString.setClusterUrl(IngestClientBase.getIngestionEndpoint(engineConnectionString.getClusterUrl()));
         return new ManagedStreamingIngestClient(dmConnectionString, engineConnectionString, properties);
     }
 
-    public ManagedStreamingIngestClient(ConnectionStringBuilder dmConnectionStringBuilder,
-            ConnectionStringBuilder engineConnectionStringBuilder) throws URISyntaxException {
-        this(dmConnectionStringBuilder, engineConnectionStringBuilder, null);
+    /**
+     * @deprecated - This method is slated to be private. Use
+     * {@link IngestClientFactory#createManagedStreamingIngestClient(ConnectionStringBuilder, ConnectionStringBuilder)}
+     * instead.
+     */
+    public ManagedStreamingIngestClient(ConnectionStringBuilder ingestionEndpointConnectionStringBuilder,
+            ConnectionStringBuilder queryEndpointConnectionStringBuilder) throws URISyntaxException {
+        this(ingestionEndpointConnectionStringBuilder, queryEndpointConnectionStringBuilder, null);
     }
 
-    public ManagedStreamingIngestClient(ConnectionStringBuilder dmConnectionStringBuilder,
-            ConnectionStringBuilder engineConnectionStringBuilder,
+    /**
+     * @deprecated - This method is slated to be private.  Use
+     * {@link IngestClientFactory#createManagedStreamingIngestClient(ConnectionStringBuilder, ConnectionStringBuilder, HttpClientProperties)} instead.
+     * This constructor should only be used for advanced cases. If your endpoints are standard, or you do not know, use
+     * {@link #ManagedStreamingIngestClient(ConnectionStringBuilder, HttpClientProperties)})} instead.
+     * @param ingestionEndpointConnectionStringBuilder - Endpoint for ingesting data, usually starts with "https://ingest-"
+     * @param queryEndpointConnectionStringBuilder - Endpoint for querying data, does not include "ingest-"
+     * @param properties - Additional properties to configure the http client
+     * @throws URISyntaxException if the connection string is invalid
+     */
+    public ManagedStreamingIngestClient(ConnectionStringBuilder ingestionEndpointConnectionStringBuilder,
+            ConnectionStringBuilder queryEndpointConnectionStringBuilder,
             @Nullable HttpClientProperties properties) throws URISyntaxException {
         log.info("Creating a new ManagedStreamingIngestClient from connection strings");
-        queuedIngestClient = new QueuedIngestClientImpl(dmConnectionStringBuilder, properties);
-        streamingIngestClient = new StreamingIngestClient(engineConnectionStringBuilder, properties);
+        queuedIngestClient = new QueuedIngestClientImpl(ingestionEndpointConnectionStringBuilder, properties);
+        streamingIngestClient = new StreamingIngestClient(queryEndpointConnectionStringBuilder, properties);
         exponentialRetryTemplate = new ExponentialRetry(ATTEMPT_COUNT);
     }
 
+    ManagedStreamingIngestClient(ConnectionStringBuilder connectionStringBuilder,
+            @Nullable HttpClientProperties properties) throws URISyntaxException {
+        log.info("Creating a new ManagedStreamingIngestClient from connection strings");
+        queuedIngestClient = new QueuedIngestClientImpl(connectionStringBuilder, properties);
+        streamingIngestClient = new StreamingIngestClient(connectionStringBuilder, properties);
+        exponentialRetryTemplate = new ExponentialRetry(ATTEMPT_COUNT);
+    }
+
+    /**
+     * @deprecated - This method is slated to be private. Use
+     * {@link IngestClientFactory#createManagedStreamingIngestClient(ConnectionStringBuilder)} instead.
+     */
     public ManagedStreamingIngestClient(ResourceManager resourceManager,
             AzureStorageClient storageClient,
             StreamingClient streamingClient) {

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientImpl.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientImpl.java
@@ -49,7 +49,6 @@ public class QueuedIngestClientImpl extends IngestClientBase implements QueuedIn
     private static final int COMPRESSED_FILE_MULTIPLIER = 11;
     private final ResourceManager resourceManager;
     private final AzureStorageClient azureStorageClient;
-    public static final String EXPECTED_SERVICE_TYPE = "DataManagement";
     private @Nullable HttpClientProperties httpClientProperties;
     private QueueRequestOptions queueRequestOptions = null;
 

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientImpl.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientImpl.java
@@ -53,17 +53,15 @@ public class QueuedIngestClientImpl extends IngestClientBase implements QueuedIn
     private @Nullable HttpClientProperties httpClientProperties;
     private QueueRequestOptions queueRequestOptions = null;
 
-    QueuedIngestClientImpl(ConnectionStringBuilder csb) throws URISyntaxException {
-        this(csb, null);
-    }
-
     QueuedIngestClientImpl(ConnectionStringBuilder csb, @Nullable HttpClientProperties properties) throws URISyntaxException {
         log.info("Creating a new IngestClient");
         httpClientProperties = properties;
-        Client client = ClientFactory.createClient(csb, httpClientProperties);
+        ConnectionStringBuilder csbWithEndpoint = new ConnectionStringBuilder(csb);
+        csbWithEndpoint.setClusterUrl(getIngestionEndpoint(csbWithEndpoint.getClusterUrl()));
+        Client client = ClientFactory.createClient(csbWithEndpoint, httpClientProperties);
         this.resourceManager = new ResourceManager(client);
         this.azureStorageClient = new AzureStorageClient(httpClientProperties);
-        this.connectionDataSource = csb.getClusterUrl();
+        this.connectionDataSource = csbWithEndpoint.getClusterUrl();
     }
 
     QueuedIngestClientImpl(ResourceManager resourceManager) {
@@ -80,14 +78,6 @@ public class QueuedIngestClientImpl extends IngestClientBase implements QueuedIn
 
     public void setQueueRequestOptions(QueueRequestOptions queueRequestOptions) {
         this.queueRequestOptions = queueRequestOptions;
-    }
-
-    public static String generateDmUriSuggestion(URIBuilder existingEndpoint) {
-        if (existingEndpoint.getHost().toLowerCase().startsWith(INGEST_PREFIX)) {
-            throw new IllegalArgumentException("The URL is already formatted as the suggested DM endpoint, so no suggestion can be made");
-        }
-        existingEndpoint.setHost(INGEST_PREFIX + existingEndpoint.getHost());
-        return existingEndpoint.toString();
     }
 
     @Override
@@ -160,7 +150,6 @@ public class QueuedIngestClientImpl extends IngestClientBase implements QueuedIn
         } catch (IOException | URISyntaxException e) {
             throw new IngestionClientException("Failed to ingest from blob", e);
         } catch (IngestionServiceException e) {
-            validateEndpointServiceType(connectionDataSource, EXPECTED_SERVICE_TYPE);
             throw e;
         }
     }
@@ -204,7 +193,6 @@ public class QueuedIngestClientImpl extends IngestClientBase implements QueuedIn
         } catch (IOException | URISyntaxException e) {
             throw new IngestionClientException("Failed to ingest from file", e);
         } catch (IngestionServiceException e) {
-            validateEndpointServiceType(connectionDataSource, EXPECTED_SERVICE_TYPE);
             throw e;
         }
     }
@@ -255,7 +243,6 @@ public class QueuedIngestClientImpl extends IngestClientBase implements QueuedIn
         } catch (StorageException e) {
             throw new IngestionServiceException("Failed to ingest from stream", e);
         } catch (IngestionServiceException e) {
-            validateEndpointServiceType(connectionDataSource, EXPECTED_SERVICE_TYPE);
             throw e;
         }
     }
@@ -297,19 +284,6 @@ public class QueuedIngestClientImpl extends IngestClientBase implements QueuedIn
             log.error(msg, ex);
             throw new IngestionClientException(msg, ex);
         }
-    }
-
-    @Override
-    protected String emendEndpointUri(URIBuilder existingEndpoint) {
-        return generateDmUriSuggestion(existingEndpoint);
-    }
-
-    @Override
-    protected String retrieveServiceType() {
-        if (resourceManager != null) {
-            return resourceManager.retrieveServiceType();
-        }
-        return null;
     }
 
     protected void setConnectionDataSource(String connectionDataSource) {

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/StreamingIngestClient.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/StreamingIngestClient.java
@@ -45,7 +45,6 @@ import java.util.zip.GZIPOutputStream;
 
 public class StreamingIngestClient extends IngestClientBase implements IngestClient {
 
-    public static final String EXPECTED_SERVICE_TYPE = "Engine";
     private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final int STREAM_COMPRESS_BUFFER_SIZE = 16 * 1024;
     private final StreamingClient streamingClient;

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClientTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClientTest.java
@@ -554,6 +554,24 @@ class ManagedStreamingIngestClientTest {
     }
 
     @Test
+    void CreateManagedStreamingIngestClient_WithDefaultCtor_WithQueryUri_Pass() throws URISyntaxException {
+        ManagedStreamingIngestClient client = IngestClientFactory.createManagedStreamingIngestClient(ConnectionStringBuilder.createWithUserPrompt("https" +
+                "://testendpoint.dev.kusto.windows.net"));
+        assertNotNull(client);
+        assertEquals("https://ingest-testendpoint.dev.kusto.windows.net", client.queuedIngestClient.connectionDataSource);
+        assertEquals("https://testendpoint.dev.kusto.windows.net", client.streamingIngestClient.connectionDataSource);
+    }
+
+    @Test
+    void CreateManagedStreamingIngestClient_WithDefaultCtor_WithIngestUri_Pass() throws URISyntaxException {
+        ManagedStreamingIngestClient client = IngestClientFactory.createManagedStreamingIngestClient(ConnectionStringBuilder.createWithUserPrompt("https" +
+                "://ingest-testendpoint.dev.kusto.windows.net"));
+        assertNotNull(client);
+        assertEquals("https://ingest-testendpoint.dev.kusto.windows.net", client.queuedIngestClient.connectionDataSource);
+        assertEquals("https://testendpoint.dev.kusto.windows.net", client.streamingIngestClient.connectionDataSource);
+    }
+
+    @Test
     void CreateManagedStreamingIngestClient_WithDmUri_Pass() throws URISyntaxException {
         ManagedStreamingIngestClient client = ManagedStreamingIngestClient
                 .fromDmConnectionString(ConnectionStringBuilder.createWithUserPrompt("https://ingest-testendpoint.dev.kusto.windows.net"));
@@ -563,28 +581,12 @@ class ManagedStreamingIngestClientTest {
     }
 
     @Test
-    void CreateManagedStreamingIngestClient_WithWrongDmUri_Fail() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            ManagedStreamingIngestClient client = ManagedStreamingIngestClient
-                    .fromDmConnectionString(ConnectionStringBuilder.createWithUserPrompt("https://testendpoint.dev.kusto.windows.net"));
-        });
-    }
-
-    @Test
     void CreateManagedStreamingIngestClient_WithEngineUri_Pass() throws URISyntaxException {
         ManagedStreamingIngestClient client = ManagedStreamingIngestClient.fromEngineConnectionString(
                 ConnectionStringBuilder.createWithUserPrompt("https://testendpoint.dev.kusto.windows.net"));
         assertNotNull(client);
         assertEquals("https://ingest-testendpoint.dev.kusto.windows.net", client.queuedIngestClient.connectionDataSource);
         assertEquals("https://testendpoint.dev.kusto.windows.net", client.streamingIngestClient.connectionDataSource);
-    }
-
-    @Test
-    void CreateManagedStreamingIngestClient_WithWrongEngineUri_Fail() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            ManagedStreamingIngestClient client = ManagedStreamingIngestClient.fromEngineConnectionString(
-                    ConnectionStringBuilder.createWithUserPrompt("https://ingest-testendpoint.dev.kusto.windows.net"));
-        });
     }
 
     private static void verifyClientRequestId() {

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClientTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClientTest.java
@@ -572,6 +572,24 @@ class ManagedStreamingIngestClientTest {
     }
 
     @Test
+    void CreateManagedStreamingIngestClient_WithDefaultCtor_WithPrivateQueryUri_Pass() throws URISyntaxException {
+        ManagedStreamingIngestClient client = IngestClientFactory.createManagedStreamingIngestClient(ConnectionStringBuilder.createWithUserPrompt("https" +
+                "://private-testendpoint.dev.kusto.windows.net"));
+        assertNotNull(client);
+        assertEquals("https://ingest-private-testendpoint.dev.kusto.windows.net", client.queuedIngestClient.connectionDataSource);
+        assertEquals("https://private-testendpoint.dev.kusto.windows.net", client.streamingIngestClient.connectionDataSource);
+    }
+
+    @Test
+    void CreateManagedStreamingIngestClient_WithDefaultCtor_WithPrivateIngestUri_Pass() throws URISyntaxException {
+        ManagedStreamingIngestClient client = IngestClientFactory.createManagedStreamingIngestClient(ConnectionStringBuilder.createWithUserPrompt("https" +
+                "://private-ingest-testendpoint.dev.kusto.windows.net"));
+        assertNotNull(client);
+        assertEquals("https://private-ingest-testendpoint.dev.kusto.windows.net", client.queuedIngestClient.connectionDataSource);
+        assertEquals("https://private-testendpoint.dev.kusto.windows.net", client.streamingIngestClient.connectionDataSource);
+    }
+
+    @Test
     void CreateManagedStreamingIngestClient_WithDmUri_Pass() throws URISyntaxException {
         ManagedStreamingIngestClient client = ManagedStreamingIngestClient
                 .fromDmConnectionString(ConnectionStringBuilder.createWithUserPrompt("https://ingest-testendpoint.dev.kusto.windows.net"));

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientTest.java
@@ -334,30 +334,6 @@ class QueuedIngestClientTest {
     }
 
     @Test
-    void IngestFromFile_GivenIngestClientAndEngineEndpoint_ThrowsIngestionServiceException() throws Exception {
-        doThrow(IngestionServiceException.class).when(resourceManagerMock).getIngestionResource(ResourceManager.ResourceType.TEMP_STORAGE);
-        when(resourceManagerMock.retrieveServiceType()).thenReturn(EXPECTED_SERVICE_TYPE);
-
-        queuedIngestClient.setConnectionDataSource("https://testendpoint.dev.kusto.windows.net");
-        FileSourceInfo fileSourceInfo = new FileSourceInfo(testFilePath, 100);
-        assertThrows(IngestionServiceException.class, () -> queuedIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties));
-    }
-
-    @Test
-    void IngestFromFile_GivenIngestClientAndEngineEndpoint_ThrowsIngestionClientException() throws Exception {
-        doThrow(IngestionServiceException.class).when(resourceManagerMock).getIngestionResource(ResourceManager.ResourceType.TEMP_STORAGE);
-        when(resourceManagerMock.retrieveServiceType()).thenReturn(ENDPOINT_SERVICE_TYPE_ENGINE);
-
-        queuedIngestClient.setConnectionDataSource("https://testendpoint.dev.kusto.windows.net");
-        FileSourceInfo fileSourceInfo = new FileSourceInfo(testFilePath, 100);
-        String expectedMessage = String.format(WRONG_ENDPOINT_MESSAGE + ", which is likely '%s'.", "is '" + ENDPOINT_SERVICE_TYPE_ENGINE + "'",
-                EXPECTED_SERVICE_TYPE,
-                "https://ingest-testendpoint.dev.kusto.windows.net");
-        Exception exception = assertThrows(IngestionClientException.class, () -> queuedIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties));
-        assertEquals(expectedMessage, exception.getMessage());
-    }
-
-    @Test
     void generateName() {
         QueuedIngestClientImpl ingestClient = new QueuedIngestClientImpl(resourceManagerMock, azureStorageClientMock);
         class Holder {

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientTest.java
@@ -33,8 +33,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.function.BiFunction;
 
-import static com.microsoft.azure.kusto.ingest.QueuedIngestClientImpl.EXPECTED_SERVICE_TYPE;
-import static com.microsoft.azure.kusto.ingest.QueuedIngestClientImpl.WRONG_ENDPOINT_MESSAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/StreamingIngestClientTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/StreamingIngestClientTest.java
@@ -352,27 +352,6 @@ class StreamingIngestClientTest {
     }
 
     @Test
-    void IngestFromFile_GivenStreamingIngestClientAndDmEndpoint_ThrowsIngestionClientException() throws Exception {
-        DataServiceException dataClientException = new DataServiceException("some cluster", "Error in post request. status 404",
-                new DataWebException("Error in post request", new BasicHttpResponse(new BasicStatusLine(new ProtocolVersion("http", 1, 1), 404, "Not found"))),
-                true);
-        doThrow(dataClientException).when(streamingClientMock).executeStreamingIngest(eq(ingestionProperties.getDatabaseName()),
-                eq(ingestionProperties.getTableName()), any(), isNull(), any(), isNull(), eq(false));
-        when(streamingClientMock.execute(Commands.VERSION_SHOW_COMMAND)).thenReturn(new KustoOperationResult(
-                "{\"Tables\":[{\"TableName\":\"Table_0\",\"Columns\":[{\"ColumnName\":\"BuildVersion\",\"DataType\":\"String\"},{\"ColumnName\":\"BuildTime\",\"DataType\":\"DateTime\"},{\"ColumnName\":\"ServiceType\",\"DataType\":\"String\"},{\"ColumnName\":\"ProductVersion\",\"DataType\":\"String\"}],\"Rows\":[[\"1.0.0.0\",\"2000-01-01T00:00:00Z\",\"DataManagement\",\"PrivateBuild.yischoen.YISCHOEN-OP7070.2020-09-07 12-09-22\"]]}]}",
-                "v1"));
-
-        streamingIngestClient.setConnectionDataSource("https://ingest-testendpoint.dev.kusto.windows.net");
-        String path = resourcesDirectory + "testdata.csv";
-        FileSourceInfo fileSourceInfo = new FileSourceInfo(path, new File(path).length());
-        String expectedMessage = String.format(WRONG_ENDPOINT_MESSAGE + ", which is likely '%s'.", "is '" + ENDPOINT_SERVICE_TYPE_DM + "'",
-                EXPECTED_SERVICE_TYPE,
-                "https://testendpoint.dev.kusto.windows.net");
-        Exception exception = assertThrows(IngestionClientException.class, () -> streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties));
-        assertEquals(expectedMessage, exception.getMessage());
-    }
-
-    @Test
     void IngestFromFile_Json() throws Exception {
         String path = resourcesDirectory + "testdata.json";
         FileSourceInfo fileSourceInfo = new FileSourceInfo(path, new File(path).length());

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/StreamingIngestClientTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/StreamingIngestClientTest.java
@@ -4,11 +4,9 @@
 package com.microsoft.azure.kusto.ingest;
 
 import com.microsoft.azure.kusto.data.ClientRequestProperties;
-import com.microsoft.azure.kusto.data.KustoOperationResult;
 import com.microsoft.azure.kusto.data.StreamingClient;
 import com.microsoft.azure.kusto.data.exceptions.DataClientException;
 import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
-import com.microsoft.azure.kusto.data.exceptions.DataWebException;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionClientException;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException;
 import com.microsoft.azure.kusto.ingest.result.IngestionResult;
@@ -22,9 +20,7 @@ import com.microsoft.azure.storage.StorageException;
 import com.microsoft.azure.storage.blob.BlobInputStream;
 import com.microsoft.azure.storage.blob.BlobProperties;
 import com.microsoft.azure.storage.blob.CloudBlockBlob;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.message.BasicHttpResponse;
-import org.apache.http.message.BasicStatusLine;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,16 +41,12 @@ import java.sql.ResultSetMetaData;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import static com.microsoft.azure.kusto.ingest.IngestClientBase.WRONG_ENDPOINT_MESSAGE;
-import static com.microsoft.azure.kusto.ingest.StreamingIngestClient.EXPECTED_SERVICE_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
Changes:

* Removed complex endpoint detection system (as per discussion)
* Automatic conversion of query/ingestion urls in ingest clients - adds or removes "ingest-"
* Changed terminology to "ingestion endpoint" and "query endpoint" where possible
* Deprecated un-needed ctors