### PR TITLE
Fix MSAL scopes bug

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
@@ -3,6 +3,7 @@ package com.microsoft.azure.kusto.data.auth;
 import com.microsoft.azure.kusto.data.UriUtils;
 
 import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
@@ -193,6 +194,7 @@ public class CloudInfo {
             resourceUrl = resourceUrl.replace(".kusto.", ".kustomfa.");
         }
 
-        return UriUtils.setPathForUri(resourceUrl, ".default");
+        resourceUrl = StringUtils.appendIfMissing(resourceUrl, "/");
+        return resourceUrl + ".default";
     }
 }


### PR DESCRIPTION
#### Pull Request Description

For the MSAL scopes URL, we want ".default" to be appended to the resource URL, not to be its path's replacement.

---

#### Future Release Comment
**Fixes:**
- For the MSAL scopes URL, we want ".default" to be appended to the resource URL, not to be its path's replacement.