### PR TITLE
Switch to jackson library from org.json

### DIFF
--- a/data/pom.xml
+++ b/data/pom.xml
@@ -171,11 +171,6 @@
             <version>${httpcore.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>${json.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>${annotations.version}</version>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -283,5 +283,15 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <version>${fasterxml.jackson.core.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${fasterxml.jackson.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>${fasterxml.jackson.core.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -277,5 +277,11 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <version>${fasterxml.jackson.core.version}</version>
         </dependency>
+        <!-- added this dependency since mvn dependency:tree failing with following error - Used undeclared dependencies found -->
+        <dependency>
+            <artifactId>jackson-core</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <version>${fasterxml.jackson.core.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
@@ -309,24 +309,23 @@ public class ClientImpl implements Client, StreamingClient {
     }
 
     private String generateCommandPayload(String database, String command, ClientRequestProperties properties, String clusterEndpoint)
-            //throws DataClientException
+    // throws DataClientException
     {
         String jsonPayload;
-        //try {
-            ObjectNode json = new ObjectMapper().createObjectNode()
-                    .put("db", database)
-                    .put("csl", command);
+        // try {
+        ObjectNode json = new ObjectMapper().createObjectNode()
+                .put("db", database)
+                .put("csl", command);
 
+        if (properties != null) {
+            json.put("properties", properties.toString());
+        }
 
-            if (properties != null) {
-                json.put("properties", properties.toString());
-            }
-
-            jsonPayload = json.asText();
-        /*} catch (JSONException e) {
-            throw new DataClientException(clusterEndpoint,
-                    String.format(clusterEndpoint, "Error executing command '%s' in database '%s'. Setting up request payload failed.", command, database), e);
-        }*/
+        jsonPayload = json.asText();
+        /*
+         * } catch (JSONException e) { throw new DataClientException(clusterEndpoint, String.format(clusterEndpoint,
+         * "Error executing command '%s' in database '%s'. Setting up request payload failed.", command, database), e); }
+         */
 
         return jsonPayload;
     }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
@@ -45,6 +45,8 @@ public class ClientImpl implements Client, StreamingClient {
     private final CloseableHttpClient httpClient;
     private boolean endpointValidated = false;
 
+    private ObjectMapper objectMapper = Utils.getObjectMapper();
+
     public ClientImpl(ConnectionStringBuilder csb) throws URISyntaxException {
         this(csb, HttpClientProperties.builder().build());
     }
@@ -309,11 +311,9 @@ public class ClientImpl implements Client, StreamingClient {
     }
 
     private String generateCommandPayload(String database, String command, ClientRequestProperties properties, String clusterEndpoint)
-    // throws DataClientException
     {
-        String jsonPayload;
-        // try {
-        ObjectNode json = new ObjectMapper().createObjectNode()
+
+        ObjectNode json = objectMapper.createObjectNode()
                 .put("db", database)
                 .put("csl", command);
 
@@ -321,13 +321,7 @@ public class ClientImpl implements Client, StreamingClient {
             json.put("properties", properties.toString());
         }
 
-        jsonPayload = json.toString();
-        /*
-         * } catch (JSONException e) { throw new DataClientException(clusterEndpoint, String.format(clusterEndpoint,
-         * "Error executing command '%s' in database '%s'. Setting up request payload failed.", command, database), e); }
-         */
-
-        return jsonPayload;
+        return json.toString();
     }
 
     private void addCommandHeaders(Map<String, String> headers) {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.azure.kusto.data;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.microsoft.azure.kusto.data.auth.CloudInfo;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
 import com.microsoft.azure.kusto.data.auth.TokenProviderBase;
@@ -16,8 +18,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -309,22 +309,24 @@ public class ClientImpl implements Client, StreamingClient {
     }
 
     private String generateCommandPayload(String database, String command, ClientRequestProperties properties, String clusterEndpoint)
-            throws DataClientException {
+            //throws DataClientException
+    {
         String jsonPayload;
-        try {
-            JSONObject json = new JSONObject()
+        //try {
+            ObjectNode json = new ObjectMapper().createObjectNode()
                     .put("db", database)
                     .put("csl", command);
+
 
             if (properties != null) {
                 json.put("properties", properties.toString());
             }
 
-            jsonPayload = json.toString();
-        } catch (JSONException e) {
+            jsonPayload = json.asText();
+        /*} catch (JSONException e) {
             throw new DataClientException(clusterEndpoint,
                     String.format(clusterEndpoint, "Error executing command '%s' in database '%s'. Setting up request payload failed.", command, database), e);
-        }
+        }*/
 
         return jsonPayload;
     }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
@@ -321,7 +321,7 @@ public class ClientImpl implements Client, StreamingClient {
             json.put("properties", properties.toString());
         }
 
-        jsonPayload = json.asText();
+        jsonPayload = json.toString();
         /*
          * } catch (JSONException e) { throw new DataClientException(clusterEndpoint, String.format(clusterEndpoint,
          * "Error executing command '%s' in database '%s'. Setting up request payload failed.", command, database), e); }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
@@ -310,8 +310,7 @@ public class ClientImpl implements Client, StreamingClient {
         return headers;
     }
 
-    private String generateCommandPayload(String database, String command, ClientRequestProperties properties, String clusterEndpoint)
-    {
+    private String generateCommandPayload(String database, String command, ClientRequestProperties properties, String clusterEndpoint) {
 
         ObjectNode json = objectMapper.createObjectNode()
                 .put("db", database)

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
@@ -5,7 +5,6 @@ package com.microsoft.azure.kusto.data;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.microsoft.azure.kusto.data.format.CslBoolFormat;
 import com.microsoft.azure.kusto.data.format.CslDateTimeFormat;
@@ -193,8 +192,7 @@ public class ClientRequestProperties implements Serializable {
     }
 
     JsonNode toJson() {
-        ObjectMapper mapper = new ObjectMapper();
-        ObjectNode optionsAsJSON = mapper.valueToTree(this.options);
+        ObjectNode optionsAsJSON = Utils.getObjectMapper().valueToTree(this.options);
         Object timeoutObj = getOption(OPTION_SERVER_TIMEOUT);
 
         if (timeoutObj != null) {
@@ -210,12 +208,12 @@ public class ClientRequestProperties implements Serializable {
             }
             optionsAsJSON.put(OPTION_SERVER_TIMEOUT, timeoutString);
         }
-        ObjectNode json = mapper.createObjectNode();
+        ObjectNode json = Utils.getObjectMapper().createObjectNode();
         if (!options.isEmpty()) {
             json.set(OPTIONS_KEY, optionsAsJSON);
         }
         if (!parameters.isEmpty()) {
-            json.set(PARAMETERS_KEY, mapper.valueToTree(this.parameters));
+            json.set(PARAMETERS_KEY, Utils.getObjectMapper().valueToTree(this.parameters));
         }
         return json;
     }
@@ -225,10 +223,9 @@ public class ClientRequestProperties implements Serializable {
     }
 
     public static ClientRequestProperties fromString(String json) throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
         if (StringUtils.isNotBlank(json)) {
             ClientRequestProperties crp = new ClientRequestProperties();
-            JsonNode jsonObj = mapper.readTree(json);
+            JsonNode jsonObj = Utils.getObjectMapper().readTree(json);
             Iterator<String> it = jsonObj.fieldNames();
             while (it.hasNext()) {
                 String propertyName = it.next();

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
@@ -193,29 +193,29 @@ public class ClientRequestProperties implements Serializable {
     }
 
     JsonNode toJson() {
-            ObjectMapper mapper = new ObjectMapper();
-            ObjectNode optionsAsJSON = mapper.valueToTree(this.options);
-            Object timeoutObj = getOption(OPTION_SERVER_TIMEOUT);
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode optionsAsJSON = mapper.valueToTree(this.options);
+        Object timeoutObj = getOption(OPTION_SERVER_TIMEOUT);
 
-            if (timeoutObj != null) {
-                String timeoutString = "";
-                if (timeoutObj instanceof Long) {
-                    Duration duration = Duration.ofMillis((Long) timeoutObj);
-                    timeoutString = Utils.formatDurationAsTimespan(duration);
-                } else if (timeoutObj instanceof String) {
-                    timeoutString = (String) timeoutObj;
-                } else if (timeoutObj instanceof Integer) {
-                    Duration duration = Duration.ofMillis((Integer) timeoutObj);
-                    timeoutString = Utils.formatDurationAsTimespan(duration);
-                }
-                optionsAsJSON.put(OPTION_SERVER_TIMEOUT, timeoutString);
+        if (timeoutObj != null) {
+            String timeoutString = "";
+            if (timeoutObj instanceof Long) {
+                Duration duration = Duration.ofMillis((Long) timeoutObj);
+                timeoutString = Utils.formatDurationAsTimespan(duration);
+            } else if (timeoutObj instanceof String) {
+                timeoutString = (String) timeoutObj;
+            } else if (timeoutObj instanceof Integer) {
+                Duration duration = Duration.ofMillis((Integer) timeoutObj);
+                timeoutString = Utils.formatDurationAsTimespan(duration);
             }
-            ObjectNode json = mapper.createObjectNode();
-            json.set(OPTIONS_KEY, optionsAsJSON);
-            if(!parameters.isEmpty()){
-                json.set(PARAMETERS_KEY, mapper.valueToTree(this.parameters));
-            }
-            return json;
+            optionsAsJSON.put(OPTION_SERVER_TIMEOUT, timeoutString);
+        }
+        ObjectNode json = mapper.createObjectNode();
+        json.set(OPTIONS_KEY, optionsAsJSON);
+        if (!parameters.isEmpty()) {
+            json.set(PARAMETERS_KEY, mapper.valueToTree(this.parameters));
+        }
+        return json;
     }
 
     public String toString() {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
@@ -209,12 +209,8 @@ public class ClientRequestProperties implements Serializable {
             optionsAsJSON.put(OPTION_SERVER_TIMEOUT, timeoutString);
         }
         ObjectNode json = Utils.getObjectMapper().createObjectNode();
-        if (!options.isEmpty()) {
-            json.set(OPTIONS_KEY, optionsAsJSON);
-        }
-        if (!parameters.isEmpty()) {
-            json.set(PARAMETERS_KEY, Utils.getObjectMapper().valueToTree(this.parameters));
-        }
+        json.set(OPTIONS_KEY, optionsAsJSON);
+        json.set(PARAMETERS_KEY, Utils.getObjectMapper().valueToTree(this.parameters));
         return json;
     }
 

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
@@ -211,7 +211,9 @@ public class ClientRequestProperties implements Serializable {
             optionsAsJSON.put(OPTION_SERVER_TIMEOUT, timeoutString);
         }
         ObjectNode json = mapper.createObjectNode();
-        json.set(OPTIONS_KEY, optionsAsJSON);
+        if(!options.isEmpty()){
+            json.set(OPTIONS_KEY, optionsAsJSON);
+        }
         if (!parameters.isEmpty()) {
             json.set(PARAMETERS_KEY, mapper.valueToTree(this.parameters));
         }
@@ -235,14 +237,14 @@ public class ClientRequestProperties implements Serializable {
                     Iterator<String> optionsIt = optionsJson.fieldNames();
                     while (optionsIt.hasNext()) {
                         String optionName = optionsIt.next();
-                        crp.setOption(optionName, optionsJson.get(optionName));
+                        crp.setOption(optionName, optionsJson.get(optionName).asText());
                     }
                 } else if (propertyName.equals(PARAMETERS_KEY)) {
                     JsonNode parameters = jsonObj.get(propertyName);
                     Iterator<String> parametersIt = parameters.fieldNames();
                     while (parametersIt.hasNext()) {
                         String parameterName = parametersIt.next();
-                        crp.setParameter(parameterName, parameters.get(parameterName));
+                        crp.setParameter(parameterName, parameters.get(parameterName).asText());
                     }
                 }
             }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
@@ -211,7 +211,7 @@ public class ClientRequestProperties implements Serializable {
             optionsAsJSON.put(OPTION_SERVER_TIMEOUT, timeoutString);
         }
         ObjectNode json = mapper.createObjectNode();
-        if(!options.isEmpty()){
+        if (!options.isEmpty()) {
             json.set(OPTIONS_KEY, optionsAsJSON);
         }
         if (!parameters.isEmpty()) {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoOperationResult.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoOperationResult.java
@@ -101,7 +101,7 @@ public class KustoOperationResult implements Iterator<KustoResultSetTable> {
         ArrayNode jsonArray;
         try {
             JsonNode jsonNode = objectMapper.readTree(response);
-            jsonArray = jsonNode.isArray()? (ArrayNode) jsonNode: null;
+            jsonArray = jsonNode.isArray() ? (ArrayNode) jsonNode : null;
             for (int i = 0; i < jsonArray.size(); i++) {
                 JsonNode table = jsonArray.get(i);
                 if (table.has(FRAME_TYPE_PROPERTY_NAME) && table.get(FRAME_TYPE_PROPERTY_NAME).toString().equals(DATA_TABLE_FRAME_TYPE_PROPERTY_NAME)) {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoOperationResult.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoOperationResult.java
@@ -115,7 +115,8 @@ public class KustoOperationResult implements Iterator<KustoResultSetTable> {
             }
         } catch (JsonProcessingException jsonProcessingException) {
             log.error("Json processing error occured while parsing string to json with exception", jsonProcessingException);
-            throw new KustoServiceQueryError("Json processing error occurred while parsing string to json with exception " + jsonProcessingException.getMessage());
+            throw new KustoServiceQueryError(
+                    "Json processing error occurred while parsing string to json with exception " + jsonProcessingException.getMessage());
         } catch (NullPointerException nullPointerException) {
             log.error("Null pointer exception thrown due to invalid v2 response", nullPointerException);
             throw new KustoServiceQueryError("Null pointer exception thrown due to invalid v2 response " + nullPointerException.getMessage());

--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoOperationResult.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoOperationResult.java
@@ -8,10 +8,15 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.microsoft.azure.kusto.data.exceptions.KustoServiceQueryError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.invoke.MethodHandles;
 import java.util.*;
 
 public class KustoOperationResult implements Iterator<KustoResultSetTable> {
+
+    private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private static final Map<String, WellKnownDataSet> tablesKindsMap = new HashMap<String, WellKnownDataSet>() {
         {
             put("QueryResult", WellKnownDataSet.PrimaryResult);
@@ -73,7 +78,8 @@ public class KustoOperationResult implements Iterator<KustoResultSetTable> {
                 }
             }
         } catch (JsonProcessingException e) {
-            throw new KustoServiceQueryError("Some error occured while parsing string to json ");
+            log.error("Json processing error occured while parsing string to json with exception", e);
+            throw new KustoServiceQueryError("Json processing error occured while parsing string to json with exception " + e.getMessage());
         }
 
         if (resultTables.size() <= 2) {
@@ -104,12 +110,13 @@ public class KustoOperationResult implements Iterator<KustoResultSetTable> {
             jsonArray = jsonNode.isArray() ? (ArrayNode) jsonNode : null;
             for (int i = 0; i < jsonArray.size(); i++) {
                 JsonNode table = jsonArray.get(i);
-                if (table.has(FRAME_TYPE_PROPERTY_NAME) && table.get(FRAME_TYPE_PROPERTY_NAME).toString().equals(DATA_TABLE_FRAME_TYPE_PROPERTY_NAME)) {
+                if (table.has(FRAME_TYPE_PROPERTY_NAME) && table.get(FRAME_TYPE_PROPERTY_NAME).asText().equals(DATA_TABLE_FRAME_TYPE_PROPERTY_NAME)) {
                     resultTables.add(new KustoResultSetTable(table));
                 }
             }
         } catch (JsonProcessingException e) {
-            throw new KustoServiceQueryError("Some error occured while parsing string to json ");
+            log.error("Json processing error occured while parsing string to json with exception", e);
+            throw new KustoServiceQueryError("Json processing error occured while parsing string to json with exception " + e.getMessage());
         }
 
     }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.microsoft.azure.kusto.data.exceptions.KustoServiceQueryError;
 
 import org.apache.commons.lang3.StringUtils;
@@ -136,7 +135,29 @@ public class KustoResultSetTable {
                     if (obj.isNull()) {
                         rowVector.add(null);
                     } else {
-                        rowVector.add(obj);
+                        switch (rowAsJsonArray.get(j).getNodeType()){
+                            case STRING:
+                                rowVector.add(obj.asText());
+                                break;
+                            case BOOLEAN:
+                                rowVector.add(obj.asBoolean());
+                                break;
+                            case NUMBER:
+                                if(obj.isInt()){
+                                    rowVector.add(obj.asInt());
+                                } else if (obj.isLong()) {
+                                    rowVector.add(obj.asLong());
+                                } else if(obj.isBigDecimal()){
+                                    rowVector.add(obj.decimalValue());
+                                }else if(obj.isDouble()){
+                                    rowVector.add(obj.asDouble());
+                                }else {
+                                    rowVector.add(obj);
+                                }
+                                break;
+                            default:
+                                rowVector.add(obj);
+                        }
                     }
                 }
                 values.add(rowVector);

--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
@@ -41,7 +41,7 @@ public class KustoResultSetTable {
     private static final String EXCEPTIONS_MESSAGE = "Query execution failed with multiple inner exceptions";
 
     private static final String EMPTY_STRING = "";
-    private static DateTimeFormatter kustoDateTimeFormatter = new DateTimeFormatterBuilder().parseCaseInsensitive()
+    private static final DateTimeFormatter kustoDateTimeFormatter = new DateTimeFormatterBuilder().parseCaseInsensitive()
             .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME).appendLiteral('Z').toFormatter();
 
     private final List<List<Object>> rows;
@@ -86,23 +86,23 @@ public class KustoResultSetTable {
         tableId = jsonTable.has(TABLE_ID_PROPERTY_NAME) ? jsonTable.get(TABLE_ID_PROPERTY_NAME).asText() : EMPTY_STRING;
         String tableKindString = jsonTable.has(TABLE_KIND_PROPERTY_NAME) ? jsonTable.get(TABLE_KIND_PROPERTY_NAME).asText() : EMPTY_STRING;
         tableKind = StringUtils.isBlank(tableKindString) ? null : WellKnownDataSet.valueOf(tableKindString);
-        ArrayNode columnsJson = null;
-        if (jsonTable.has(COLUMNS_PROPERTY_NAME) && jsonTable.get(COLUMNS_PROPERTY_NAME).getNodeType() == JsonNodeType.ARRAY) {
-            columnsJson = (ArrayNode) jsonTable.get(COLUMNS_PROPERTY_NAME);
-        }
-        if (columnsJson != null) {
-            columnsAsArray = new KustoResultColumn[columnsJson.size()];
-            for (int i = 0; i < columnsJson.size(); i++) {
-                JsonNode jsonCol = columnsJson.get(i);
 
-                String columnType = jsonCol.has(COLUMN_TYPE_PROPERTY_NAME) ? jsonCol.get(COLUMN_TYPE_PROPERTY_NAME).asText() : EMPTY_STRING;
-                if (columnType.equals("")) {
-                    columnType = jsonCol.has(COLUMN_TYPE_SECOND_PROPERTY_NAME) ? jsonCol.get(COLUMN_TYPE_SECOND_PROPERTY_NAME).asText() : EMPTY_STRING;
+        if (jsonTable.has(COLUMNS_PROPERTY_NAME) && jsonTable.get(COLUMNS_PROPERTY_NAME).getNodeType() == JsonNodeType.ARRAY) {
+            ArrayNode columnsJson = (ArrayNode) jsonTable.get(COLUMNS_PROPERTY_NAME);
+            if (columnsJson != null) {
+                columnsAsArray = new KustoResultColumn[columnsJson.size()];
+                for (int i = 0; i < columnsJson.size(); i++) {
+                    JsonNode jsonCol = columnsJson.get(i);
+
+                    String columnType = jsonCol.has(COLUMN_TYPE_PROPERTY_NAME) ? jsonCol.get(COLUMN_TYPE_PROPERTY_NAME).asText() : EMPTY_STRING;
+                    if (columnType.equals("")) {
+                        columnType = jsonCol.has(COLUMN_TYPE_SECOND_PROPERTY_NAME) ? jsonCol.get(COLUMN_TYPE_SECOND_PROPERTY_NAME).asText() : EMPTY_STRING;
+                    }
+                    KustoResultColumn col = new KustoResultColumn(
+                            jsonCol.has(COLUMN_NAME_PROPERTY_NAME) ? jsonCol.get(COLUMN_NAME_PROPERTY_NAME).asText() : EMPTY_STRING, columnType, i);
+                    columnsAsArray[i] = col;
+                    columns.put(jsonCol.has(COLUMN_NAME_PROPERTY_NAME) ? jsonCol.get(COLUMN_NAME_PROPERTY_NAME).asText() : EMPTY_STRING, col);
                 }
-                KustoResultColumn col = new KustoResultColumn(
-                        jsonCol.has(COLUMN_NAME_PROPERTY_NAME) ? jsonCol.get(COLUMN_NAME_PROPERTY_NAME).asText() : EMPTY_STRING, columnType, i);
-                columnsAsArray[i] = col;
-                columns.put(jsonCol.has(COLUMN_NAME_PROPERTY_NAME) ? jsonCol.get(COLUMN_NAME_PROPERTY_NAME).asText() : EMPTY_STRING, col);
             }
         }
 

--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
@@ -140,7 +140,7 @@ public class KustoResultSetTable {
                 }
                 ArrayNode rowAsJsonArray = (ArrayNode) jsonRows.get(i);
                 List<Object> rowVector = new ArrayList<>();
-                for (int j = 0; j < rowAsJsonArray.size(); ++j) {
+                for (int j = 0; j < rowAsJsonArray.size(); j++) {
                     JsonNode obj = rowAsJsonArray.get(j);
                     if (obj.isNull()) {
                         rowVector.add(null);
@@ -161,6 +161,10 @@ public class KustoResultSetTable {
                                     rowVector.add(obj.decimalValue());
                                 } else if (obj.isDouble()) {
                                     rowVector.add(obj.asDouble());
+                                } else if (obj.isShort()) {
+                                    rowVector.add(obj.shortValue());
+                                } else if (obj.isFloat()) {
+                                    rowVector.add(obj.floatValue());
                                 } else {
                                     rowVector.add(obj);
                                 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
@@ -83,12 +83,12 @@ public class KustoResultSetTable {
     }
 
     protected KustoResultSetTable(JsonNode jsonTable) throws KustoServiceQueryError, JsonProcessingException {
-        tableName = jsonTable.has(TABLE_NAME_PROPERTY_NAME)?jsonTable.get(TABLE_NAME_PROPERTY_NAME).asText():EMPTY_STRING;
-        tableId = jsonTable.has(TABLE_ID_PROPERTY_NAME)?jsonTable.get(TABLE_ID_PROPERTY_NAME).asText():EMPTY_STRING;
-        String tableKindString = jsonTable.has(TABLE_KIND_PROPERTY_NAME)?jsonTable.get(TABLE_KIND_PROPERTY_NAME).asText():EMPTY_STRING;
+        tableName = jsonTable.has(TABLE_NAME_PROPERTY_NAME) ? jsonTable.get(TABLE_NAME_PROPERTY_NAME).asText() : EMPTY_STRING;
+        tableId = jsonTable.has(TABLE_ID_PROPERTY_NAME) ? jsonTable.get(TABLE_ID_PROPERTY_NAME).asText() : EMPTY_STRING;
+        String tableKindString = jsonTable.has(TABLE_KIND_PROPERTY_NAME) ? jsonTable.get(TABLE_KIND_PROPERTY_NAME).asText() : EMPTY_STRING;
         tableKind = StringUtils.isBlank(tableKindString) ? null : WellKnownDataSet.valueOf(tableKindString);
         ArrayNode columnsJson = null;
-        if(jsonTable.has(COLUMNS_PROPERTY_NAME) && jsonTable.get(COLUMNS_PROPERTY_NAME).getNodeType() == JsonNodeType.ARRAY){
+        if (jsonTable.has(COLUMNS_PROPERTY_NAME) && jsonTable.get(COLUMNS_PROPERTY_NAME).getNodeType() == JsonNodeType.ARRAY) {
             columnsJson = (ArrayNode) jsonTable.get(COLUMNS_PROPERTY_NAME);
         }
         if (columnsJson != null) {
@@ -96,27 +96,28 @@ public class KustoResultSetTable {
             for (int i = 0; i < columnsJson.size(); i++) {
                 JsonNode jsonCol = columnsJson.get(i);
 
-                String columnType = jsonCol.has(COLUMN_TYPE_PROPERTY_NAME)?jsonCol.get(COLUMN_TYPE_PROPERTY_NAME).asText():EMPTY_STRING;
+                String columnType = jsonCol.has(COLUMN_TYPE_PROPERTY_NAME) ? jsonCol.get(COLUMN_TYPE_PROPERTY_NAME).asText() : EMPTY_STRING;
                 if (columnType.equals("")) {
-                    columnType = jsonCol.has(COLUMN_TYPE_SECOND_PROPERTY_NAME)?jsonCol.get(COLUMN_TYPE_SECOND_PROPERTY_NAME).asText():EMPTY_STRING;
+                    columnType = jsonCol.has(COLUMN_TYPE_SECOND_PROPERTY_NAME) ? jsonCol.get(COLUMN_TYPE_SECOND_PROPERTY_NAME).asText() : EMPTY_STRING;
                 }
-                KustoResultColumn col = new KustoResultColumn(jsonCol.has(COLUMN_NAME_PROPERTY_NAME)?jsonCol.get(COLUMN_NAME_PROPERTY_NAME).asText():EMPTY_STRING, columnType, i);
+                KustoResultColumn col = new KustoResultColumn(
+                        jsonCol.has(COLUMN_NAME_PROPERTY_NAME) ? jsonCol.get(COLUMN_NAME_PROPERTY_NAME).asText() : EMPTY_STRING, columnType, i);
                 columnsAsArray[i] = col;
-                columns.put(jsonCol.has(COLUMN_NAME_PROPERTY_NAME)?jsonCol.get(COLUMN_NAME_PROPERTY_NAME).asText():EMPTY_STRING, col);
+                columns.put(jsonCol.has(COLUMN_NAME_PROPERTY_NAME) ? jsonCol.get(COLUMN_NAME_PROPERTY_NAME).asText() : EMPTY_STRING, col);
             }
         }
 
         ArrayNode exceptions;
         ArrayNode jsonRows = null;
-        if(jsonTable.has(ROWS_PROPERTY_NAME) && jsonTable.get(ROWS_PROPERTY_NAME).getNodeType() == JsonNodeType.ARRAY){
+        if (jsonTable.has(ROWS_PROPERTY_NAME) && jsonTable.get(ROWS_PROPERTY_NAME).getNodeType() == JsonNodeType.ARRAY) {
             jsonRows = (ArrayNode) jsonTable.get(ROWS_PROPERTY_NAME);
         }
         if (jsonRows != null) {
             List<List<Object>> values = new ArrayList<>();
             for (int i = 0; i < jsonRows.size(); i++) {
                 JsonNode row = jsonRows.get(i);
-                if (jsonRows.get(i).getNodeType() == JsonNodeType.OBJECT ) {
-                    exceptions = row.has(EXCEPTIONS_PROPERTY_NAME)?((ArrayNode)row.get(EXCEPTIONS_PROPERTY_NAME)):null;
+                if (jsonRows.get(i).getNodeType() == JsonNodeType.OBJECT) {
+                    exceptions = row.has(EXCEPTIONS_PROPERTY_NAME) ? ((ArrayNode) row.get(EXCEPTIONS_PROPERTY_NAME)) : null;
                     if (exceptions != null) {
                         if (exceptions.size() == 1) {
                             String message = exceptions.get(0).asText();

--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoResultSetTable.java
@@ -135,7 +135,7 @@ public class KustoResultSetTable {
                     if (obj.isNull()) {
                         rowVector.add(null);
                     } else {
-                        switch (rowAsJsonArray.get(j).getNodeType()){
+                        switch (rowAsJsonArray.get(j).getNodeType()) {
                             case STRING:
                                 rowVector.add(obj.asText());
                                 break;
@@ -143,15 +143,15 @@ public class KustoResultSetTable {
                                 rowVector.add(obj.asBoolean());
                                 break;
                             case NUMBER:
-                                if(obj.isInt()){
+                                if (obj.isInt()) {
                                     rowVector.add(obj.asInt());
                                 } else if (obj.isLong()) {
                                     rowVector.add(obj.asLong());
-                                } else if(obj.isBigDecimal()){
+                                } else if (obj.isBigDecimal()) {
                                     rowVector.add(obj.decimalValue());
-                                }else if(obj.isDouble()){
+                                } else if (obj.isDouble()) {
                                     rowVector.add(obj.asDouble());
-                                }else {
+                                } else {
                                     rowVector.add(obj);
                                 }
                                 break;

--- a/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
@@ -54,7 +54,7 @@ public class Utils {
     private static final int MAX_REDIRECT_COUNT = 1;
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    public static ObjectMapper getObjectMapper(){
+    public static ObjectMapper getObjectMapper() {
         return JsonMapper.builder().addModule(new JavaTimeModule()).addModule(new Jdk8Module()).build();
     }
 

--- a/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
@@ -194,12 +194,9 @@ public class Utils {
                     } else if (jsonObject.has("message")) {
                         message = jsonObject.get("message").asText();
                     }
-                } catch (JsonMappingException e) {
-                    // It's not ideal to use an exception here for control flow, but we can't know if it's a valid JSON until we try to parse it
-                    LOGGER.error("json mapping error happened while parsing errorFromResponse {} {}", e.getMessage(), e);
                 } catch (JsonProcessingException e) {
                     // It's not ideal to use an exception here for control flow, but we can't know if it's a valid JSON until we try to parse it
-                    LOGGER.error("json processing error happened while parsing errorFromResponse {} {}" + e.getMessage(), e);
+                    LOGGER.debug("json processing error happened while parsing errorFromResponse {} {}" + e.getMessage(), e);
                 }
             } else {
                 message = String.format("Http StatusCode='%s'", httpResponse.getStatusLine().toString());

--- a/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
@@ -185,7 +185,7 @@ class Utils {
                         message = apiError.getDescription();
                         isPermanent = apiError.isPermanent();
                     } else if (jsonObject.has("message")) {
-                        message = jsonObject.get("message").toString();
+                        message = jsonObject.get("message").asText();
                     }
                 } catch (JsonMappingException e) {
                     // It's not ideal to use an exception here for control flow, but we can't know if it's a valid JSON until we try to parse it

--- a/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
@@ -57,6 +57,8 @@ public class Utils {
     private static final int MAX_REDIRECT_COUNT = 1;
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+    // added auto bigdecimal deserialization for float and double value, since the bigdecimal values seem to loose precision while auto deserialization to
+    // double value
     public static ObjectMapper getObjectMapper() {
         return JsonMapper.builder().addModule(new JavaTimeModule()).addModule(new Jdk8Module()).build().configure(
                 DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true).configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true).setNodeFactory(

--- a/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
@@ -189,10 +189,10 @@ class Utils {
                     }
                 } catch (JsonMappingException e) {
                     // It's not ideal to use an exception here for control flow, but we can't know if it's a valid JSON until we try to parse it
-                    LOGGER.error("json mapping error happened while parsing errorFromResponse"+e.getMessage(),e);
+                    LOGGER.error("json mapping error happened while parsing errorFromResponse" + e.getMessage(), e);
                 } catch (JsonProcessingException e) {
                     // It's not ideal to use an exception here for control flow, but we can't know if it's a valid JSON until we try to parse it
-                    LOGGER.error("json processing error happened while parsing errorFromResponse"+e.getMessage(),e);
+                    LOGGER.error("json processing error happened while parsing errorFromResponse" + e.getMessage(), e);
                 }
             } else {
                 message = String.format("Http StatusCode='%s'", httpResponse.getStatusLine().toString());

--- a/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
@@ -3,11 +3,14 @@
 
 package com.microsoft.azure.kusto.data;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.microsoft.azure.kusto.data.auth.CloudInfo;
@@ -55,7 +58,9 @@ public class Utils {
     private static final Logger LOGGER = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public static ObjectMapper getObjectMapper() {
-        return JsonMapper.builder().addModule(new JavaTimeModule()).addModule(new Jdk8Module()).build();
+        return JsonMapper.builder().addModule(new JavaTimeModule()).addModule(new Jdk8Module()).build().configure(
+                DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true).configure(JsonGenerator.Feature.WRITE_BIGDECIMAL_AS_PLAIN, true).setNodeFactory(
+                        JsonNodeFactory.withExactBigDecimals(true));
     }
 
     private Utils() {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.kusto.data.UriUtils;
 
+import com.microsoft.azure.kusto.data.Utils;
 import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
@@ -129,7 +130,7 @@ public class CloudInfo {
     }
 
     private static CloudInfo parseCloudInfo(String content) throws JsonProcessingException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = Utils.getObjectMapper();
         JsonNode jsonObject = objectMapper.readTree(content);
         JsonNode innerObject = jsonObject.has("AzureAD") ? jsonObject.get("AzureAD") : null;
         if (innerObject == null) {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
@@ -134,14 +134,14 @@ public class CloudInfo {
         JsonNode innerObject = jsonObject.has("AzureAD") ? jsonObject.get("AzureAD") : null;
         if (innerObject == null) {
             return DEFAULT_CLOUD;
-        }else{
+        } else {
             return new CloudInfo(
                     innerObject.has("LoginMfaRequired") && innerObject.get("LoginMfaRequired").asBoolean(),
-                    innerObject.has("LoginEndpoint")?innerObject.get("LoginEndpoint").asText():"",
-                    innerObject.has("KustoClientAppId")?innerObject.get("KustoClientAppId").asText():"",
-                    innerObject.has("KustoClientRedirectUri")?innerObject.get("KustoClientRedirectUri").asText():"",
-                    innerObject.has("KustoServiceResourceId")?innerObject.get("KustoServiceResourceId").asText():"",
-                    innerObject.has("FirstPartyAuthorityUrl")?innerObject.get("FirstPartyAuthorityUrl").asText():"");
+                    innerObject.has("LoginEndpoint") ? innerObject.get("LoginEndpoint").asText() : "",
+                    innerObject.has("KustoClientAppId") ? innerObject.get("KustoClientAppId").asText() : "",
+                    innerObject.has("KustoClientRedirectUri") ? innerObject.get("KustoClientRedirectUri").asText() : "",
+                    innerObject.has("KustoServiceResourceId") ? innerObject.get("KustoServiceResourceId").asText() : "",
+                    innerObject.has("FirstPartyAuthorityUrl") ? innerObject.get("FirstPartyAuthorityUrl").asText() : "");
         }
 
     }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
@@ -131,7 +131,7 @@ public class CloudInfo {
     private static CloudInfo parseCloudInfo(String content) throws JsonProcessingException {
         ObjectMapper objectMapper = new ObjectMapper();
         JsonNode jsonObject = objectMapper.readTree(content);
-        JsonNode innerObject = jsonObject.has("AzureAD")?jsonObject.get("AzureAD"):null;
+        JsonNode innerObject = jsonObject.has("AzureAD") ? jsonObject.get("AzureAD") : null;
         if (innerObject == null) {
             return DEFAULT_CLOUD;
         }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
@@ -134,14 +134,16 @@ public class CloudInfo {
         JsonNode innerObject = jsonObject.has("AzureAD") ? jsonObject.get("AzureAD") : null;
         if (innerObject == null) {
             return DEFAULT_CLOUD;
+        }else{
+            return new CloudInfo(
+                    innerObject.has("LoginMfaRequired") && innerObject.get("LoginMfaRequired").asBoolean(),
+                    innerObject.has("LoginEndpoint")?innerObject.get("LoginEndpoint").asText():"",
+                    innerObject.has("KustoClientAppId")?innerObject.get("KustoClientAppId").asText():"",
+                    innerObject.has("KustoClientRedirectUri")?innerObject.get("KustoClientRedirectUri").asText():"",
+                    innerObject.has("KustoServiceResourceId")?innerObject.get("KustoServiceResourceId").asText():"",
+                    innerObject.has("FirstPartyAuthorityUrl")?innerObject.get("FirstPartyAuthorityUrl").asText():"");
         }
-        return new CloudInfo(
-                innerObject.get("LoginMfaRequired").asBoolean(),
-                innerObject.get("LoginEndpoint").asText(),
-                innerObject.get("KustoClientAppId").asText(),
-                innerObject.get("KustoClientRedirectUri").asText(),
-                innerObject.get("KustoServiceResourceId").asText(),
-                innerObject.get("FirstPartyAuthorityUrl").asText());
+
     }
 
     @Override

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/endpoints/WellKnownKustoEndpointsData.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/endpoints/WellKnownKustoEndpointsData.java
@@ -2,6 +2,7 @@ package com.microsoft.azure.kusto.data.auth.endpoints;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.kusto.data.Utils;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -37,7 +38,7 @@ public class WellKnownKustoEndpointsData {
     private static WellKnownKustoEndpointsData readInstance() {
         try {
             // Beautiful !
-            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectMapper objectMapper = Utils.getObjectMapper();
             try (InputStream resourceAsStream = WellKnownKustoEndpointsData.class.getResourceAsStream(
                     "/WellKnownKustoEndpoints.json")) {
                 return objectMapper.readValue(resourceAsStream, WellKnownKustoEndpointsData.class);

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataWebException.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataWebException.java
@@ -5,6 +5,7 @@ package com.microsoft.azure.kusto.data.exceptions;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.kusto.data.Utils;
 import org.apache.http.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -15,6 +16,7 @@ public class DataWebException extends WebException {
     private OneApiError apiError = null;
 
     private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private ObjectMapper objectMapper = Utils.getObjectMapper();
 
     public DataWebException(String message, HttpResponse httpResponse, Throwable cause) {
         super(message, httpResponse, cause);
@@ -31,9 +33,9 @@ public class DataWebException extends WebException {
     public OneApiError getApiError() {
         if (apiError == null) {
             try {
-                apiError = OneApiError.fromJsonObject(new ObjectMapper().readTree(getMessage()).get("error"));
+                apiError = OneApiError.fromJsonObject(objectMapper.readTree(getMessage()).get("error"));
             } catch (JsonProcessingException e) {
-                log.error("failed to parse error from message " + e.getMessage(), e);
+                log.error("failed to parse error from message {} {} " , e.getMessage(), e);
             }
         }
         return apiError;

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataWebException.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataWebException.java
@@ -33,7 +33,7 @@ public class DataWebException extends WebException {
             try {
                 apiError = OneApiError.fromJsonObject(new ObjectMapper().readTree(getMessage()).get("error"));
             } catch (JsonProcessingException e) {
-                log.error("failed to parse error from message "+e.getMessage(),e);
+                log.error("failed to parse error from message " + e.getMessage(), e);
             }
         }
         return apiError;

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataWebException.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataWebException.java
@@ -3,11 +3,18 @@
 
 package com.microsoft.azure.kusto.data.exceptions;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
-import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
 
 public class DataWebException extends WebException {
     private OneApiError apiError = null;
+
+    private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public DataWebException(String message, HttpResponse httpResponse, Throwable cause) {
         super(message, httpResponse, cause);
@@ -23,7 +30,11 @@ public class DataWebException extends WebException {
 
     public OneApiError getApiError() {
         if (apiError == null) {
-            apiError = OneApiError.fromJsonObject(new JSONObject(getMessage()).getJSONObject("error"));
+            try {
+                apiError = OneApiError.fromJsonObject(new ObjectMapper().readTree(getMessage()).get("error"));
+            } catch (JsonProcessingException e) {
+                log.error("failed to parse error from message "+e.getMessage(),e);
+            }
         }
         return apiError;
     }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataWebException.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/DataWebException.java
@@ -35,7 +35,7 @@ public class DataWebException extends WebException {
             try {
                 apiError = OneApiError.fromJsonObject(objectMapper.readTree(getMessage()).get("error"));
             } catch (JsonProcessingException e) {
-                log.error("failed to parse error from message {} {} " , e.getMessage(), e);
+                log.error("failed to parse error from message {} {} ", e.getMessage(), e);
             }
         }
         return apiError;

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/JsonPropertyMissingException.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/JsonPropertyMissingException.java
@@ -1,0 +1,8 @@
+package com.microsoft.azure.kusto.data.exceptions;
+
+public class JsonPropertyMissingException extends Exception {
+
+    public JsonPropertyMissingException(String message) {
+        super(message);
+    }
+}

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/KustoServiceQueryError.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/KustoServiceQueryError.java
@@ -19,7 +19,7 @@ public class KustoServiceQueryError extends Exception {
     public KustoServiceQueryError(ArrayNode jsonExceptions, boolean isOneApi, String message) {
         super(message);
         this.exceptions = new ArrayList<>();
-        for (int j = 0; jsonExceptions!=null && j < jsonExceptions.size(); j++) {
+        for (int j = 0; jsonExceptions != null && j < jsonExceptions.size(); j++) {
             if (isOneApi) {
                 this.exceptions.add(new DataWebException(jsonExceptions.get(j).toString()));
             } else {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/KustoServiceQueryError.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/KustoServiceQueryError.java
@@ -3,8 +3,9 @@
 
 package com.microsoft.azure.kusto.data.exceptions;
 
-import org.json.JSONArray;
-import org.json.JSONException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,14 +16,14 @@ import java.util.List;
 public class KustoServiceQueryError extends Exception {
     private final List<Exception> exceptions;
 
-    public KustoServiceQueryError(JSONArray jsonExceptions, boolean isOneApi, String message) throws JSONException {
+    public KustoServiceQueryError(ArrayNode jsonExceptions, boolean isOneApi, String message) {
         super(message);
         this.exceptions = new ArrayList<>();
-        for (int j = 0; j < jsonExceptions.length(); j++) {
+        for (int j = 0; jsonExceptions!=null && j < jsonExceptions.size(); j++) {
             if (isOneApi) {
-                this.exceptions.add(new DataWebException(jsonExceptions.getJSONObject(j).toString()));
+                this.exceptions.add(new DataWebException(jsonExceptions.get(j).toString()));
             } else {
-                this.exceptions.add(new Exception(jsonExceptions.getString(j)));
+                this.exceptions.add(new Exception(jsonExceptions.get(j).toString()));
             }
         }
     }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/OneApiError.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/OneApiError.java
@@ -3,10 +3,10 @@
 
 package com.microsoft.azure.kusto.data.exceptions;
 
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class OneApiError {
-    public OneApiError(String code, String message, String description, String type, JSONObject context, boolean permanent) {
+    public OneApiError(String code, String message, String description, String type, JsonNode context, boolean permanent) {
         this.code = code;
         this.message = message;
         this.description = description;
@@ -15,21 +15,21 @@ public class OneApiError {
         this.permanent = permanent;
     }
 
-    public static OneApiError fromJsonObject(JSONObject jsonObject) {
+    public static OneApiError fromJsonObject(JsonNode jsonObject) {
         return new OneApiError(
-                jsonObject.getString("code"),
-                jsonObject.getString("message"),
-                jsonObject.getString("@message"),
-                jsonObject.getString("@type"),
-                jsonObject.getJSONObject("@context"),
-                jsonObject.getBoolean("@permanent"));
+                jsonObject.get("code").asText(),
+                jsonObject.get("message").asText(),
+                jsonObject.get("@message").asText(),
+                jsonObject.get("@type").asText(),
+                jsonObject.get("@context"),
+                jsonObject.get("@permanent").asBoolean());
     }
 
     private final String code;
     private final String message;
     private final String description;
     private final String type;
-    private final JSONObject context;
+    private final JsonNode context;
     private final boolean permanent;
 
     public String getCode() {
@@ -48,7 +48,7 @@ public class OneApiError {
         return type;
     }
 
-    public JSONObject getContext() {
+    public JsonNode getContext() {
         return context;
     }
 

--- a/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/OneApiError.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/exceptions/OneApiError.java
@@ -17,12 +17,12 @@ public class OneApiError {
 
     public static OneApiError fromJsonObject(JsonNode jsonObject) {
         return new OneApiError(
-                jsonObject.get("code").asText(),
-                jsonObject.get("message").asText(),
-                jsonObject.get("@message").asText(),
-                jsonObject.get("@type").asText(),
+                jsonObject.has("code") ? jsonObject.get("code").asText() : "",
+                jsonObject.has("message") ? jsonObject.get("message").asText() : "",
+                jsonObject.has("@message") ? jsonObject.get("@message").asText() : "",
+                jsonObject.has("@type") ? jsonObject.get("@type").asText() : "",
                 jsonObject.get("@context"),
-                jsonObject.get("@permanent").asBoolean());
+                jsonObject.has("@permanent") && jsonObject.get("@permanent").asBoolean());
     }
 
     private final String code;

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -10,7 +10,6 @@ import com.microsoft.azure.kusto.data.format.CslTimespanFormat;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -39,8 +38,9 @@ class ClientRequestPropertiesTest {
         ClientRequestProperties props = new ClientRequestProperties();
         props.setOption("a", 1);
         props.setOption("b", "hello");
+        ObjectMapper objectMapper = new ObjectMapper();
 
-        Assertions.assertEquals(new ObjectMapper().readTree("{\"Options\": {\"a\":1, \"b\":\"hello\"}}").toString(), props.toString());
+        Assertions.assertEquals(objectMapper.readTree("{\"Options\": {\"a\":1, \"b\":\"hello\"}}").toString(), props.toString());
     }
 
     @Test

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -40,7 +40,7 @@ class ClientRequestPropertiesTest {
         props.setOption("b", "hello");
         ObjectMapper objectMapper = Utils.getObjectMapper();
 
-        Assertions.assertEquals(objectMapper.readTree("{\"Options\": {\"a\":1, \"b\":\"hello\"}}").toString(), props.toString());
+        Assertions.assertEquals(objectMapper.readTree("{\"Options\":{\"a\":1,\"b\":\"hello\"},\"Parameters\":{}}").toString(), props.toString());
     }
 
     @Test

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -48,6 +48,7 @@ class ClientRequestPropertiesTest {
     void stringToProperties() throws JsonProcessingException {
         String properties = "{\"Options\":{\"servertimeout\":\"01:25:11.111\", \"Content-Encoding\":\"gzip\"},\"Parameters\":{\"birthday\":\"datetime(1970-05-11)\",\"courses\":\"dynamic(['Java', 'C++'])\"}}";
         ClientRequestProperties crp = ClientRequestProperties.fromString(properties);
+
         assert crp != null;
         assert crp.toJson().get("Options").get("servertimeout").asText().equals("01:25:11.111");
         assert crp.getTimeoutInMilliSec() != null;

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -38,7 +38,7 @@ class ClientRequestPropertiesTest {
         ClientRequestProperties props = new ClientRequestProperties();
         props.setOption("a", 1);
         props.setOption("b", "hello");
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = Utils.getObjectMapper();
 
         Assertions.assertEquals(objectMapper.readTree("{\"Options\": {\"a\":1, \"b\":\"hello\"}}").toString(), props.toString());
     }

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -39,7 +39,6 @@ class ClientRequestPropertiesTest {
         ClientRequestProperties props = new ClientRequestProperties();
         props.setOption("a", 1);
         props.setOption("b", "hello");
-        props.setParameter("", "");
 
         Assertions.assertEquals(new ObjectMapper().readTree("{\"Options\": {\"a\":1, \"b\":\"hello\"}}").toString(), props.toString());
     }
@@ -50,7 +49,7 @@ class ClientRequestPropertiesTest {
         String properties = "{\"Options\":{\"servertimeout\":\"01:25:11.111\", \"Content-Encoding\":\"gzip\"},\"Parameters\":{\"birthday\":\"datetime(1970-05-11)\",\"courses\":\"dynamic(['Java', 'C++'])\"}}";
         ClientRequestProperties crp = ClientRequestProperties.fromString(properties);
         assert crp != null;
-        assert crp.toJson().get("Options").get("servertimeout").toString().equals("01:25:11.111");
+        assert crp.toJson().get("Options").get("servertimeout").asText().equals("01:25:11.111");
         assert crp.getTimeoutInMilliSec() != null;
         assert crp.getOption("Content-Encoding").equals("gzip");
         assert crp.getParameter("birthday").equals("datetime(1970-05-11)");

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -39,7 +39,7 @@ class ClientRequestPropertiesTest {
         props.setOption("a", 1);
         props.setOption("b", "hello");
         ObjectMapper objectMapper = Utils.getObjectMapper();
-        
+
         Assertions.assertEquals(objectMapper.readTree("{\"Options\":{\"a\":1,\"b\":\"hello\"},\"Parameters\":{}}").toString(), props.toString());
     }
 

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -39,7 +39,7 @@ class ClientRequestPropertiesTest {
         ClientRequestProperties props = new ClientRequestProperties();
         props.setOption("a", 1);
         props.setOption("b", "hello");
-        props.setParameter("","");
+        props.setParameter("", "");
 
         Assertions.assertEquals(new ObjectMapper().readTree("{\"Options\": {\"a\":1, \"b\":\"hello\"}}").toString(), props.toString());
     }

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -3,9 +3,10 @@
 
 package com.microsoft.azure.kusto.data;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.kusto.data.format.CslDateTimeFormat;
 import com.microsoft.azure.kusto.data.format.CslTimespanFormat;
-import org.json.JSONException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,21 +35,22 @@ class ClientRequestPropertiesTest {
 
     @Test
     @DisplayName("test ClientRequestProperties toString")
-    void propertiesToString() throws JSONException {
+    void propertiesToString() throws JsonProcessingException {
         ClientRequestProperties props = new ClientRequestProperties();
         props.setOption("a", 1);
         props.setOption("b", "hello");
+        props.setParameter("","");
 
-        JSONAssert.assertEquals("{\"Options\": {\"a\":1, \"b\":\"hello\"}}", props.toString(), false);
+        Assertions.assertEquals(new ObjectMapper().readTree("{\"Options\": {\"a\":1, \"b\":\"hello\"}}").toString(), props.toString());
     }
 
     @Test
     @DisplayName("test ClientRequestProperties fromString")
-    void stringToProperties() throws JSONException {
+    void stringToProperties() throws JsonProcessingException {
         String properties = "{\"Options\":{\"servertimeout\":\"01:25:11.111\", \"Content-Encoding\":\"gzip\"},\"Parameters\":{\"birthday\":\"datetime(1970-05-11)\",\"courses\":\"dynamic(['Java', 'C++'])\"}}";
         ClientRequestProperties crp = ClientRequestProperties.fromString(properties);
         assert crp != null;
-        assert crp.toJson().getJSONObject("Options").get("servertimeout").equals("01:25:11.111");
+        assert crp.toJson().get("Options").get("servertimeout").toString().equals("01:25:11.111");
         assert crp.getTimeoutInMilliSec() != null;
         assert crp.getOption("Content-Encoding").equals("gzip");
         assert crp.getParameter("birthday").equals("datetime(1970-05-11)");

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -39,7 +39,7 @@ class ClientRequestPropertiesTest {
         props.setOption("a", 1);
         props.setOption("b", "hello");
         ObjectMapper objectMapper = Utils.getObjectMapper();
-
+        
         Assertions.assertEquals(objectMapper.readTree("{\"Options\":{\"a\":1,\"b\":\"hello\"},\"Parameters\":{}}").toString(), props.toString());
     }
 

--- a/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
@@ -1,59 +1,64 @@
 package com.microsoft.azure.kusto.data;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
 
 public class KustoDateTimeTest {
     @Test
     void KustoResultSet() throws Exception {
-        JSONArray rows = new JSONArray();
-        JSONArray row = new JSONArray();
-        row.put(Instant.parse("2022-05-17T00:00:00Z"));
-        rows.put(row);
-        row = new JSONArray();
-        row.put(Instant.parse("2022-05-17T00:00:00.1Z"));
-        rows.put(row);
-        row = new JSONArray();
-        row.put(Instant.parse("2022-05-17T00:00:00.12Z"));
-        rows.put(row);
-        row = new JSONArray();
-        row.put(Instant.parse("2022-05-17T00:00:00.123Z"));
-        rows.put(row);
-        row = new JSONArray();
-        row.put(Instant.parse("2022-05-17T00:00:00.1234Z"));
-        rows.put(row);
-        row = new JSONArray();
-        row.put(Instant.parse("2022-05-17T00:00:00.12345Z"));
-        rows.put(row);
-        row = new JSONArray();
-        row.put(Instant.parse("2022-05-17T00:00:00.123456Z"));
-        rows.put(row);
-        row = new JSONArray();
-        row.put(Instant.parse("2022-05-17T00:00:00.1234567Z"));
-        rows.put(row);
-        row = new JSONArray();
-        row.put(Instant.parse("2022-05-17T00:00:00.12345678Z"));
-        rows.put(row);
-        row = new JSONArray();
-        row.put(Instant.parse("2022-05-17T00:00:00.123456789Z"));
-        rows.put(row);
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ");
+        ObjectMapper mapper = new ObjectMapper();
+        ArrayNode rows = mapper.createArrayNode();
+        ArrayNode row = mapper.createArrayNode();
+        row.add(Instant.parse("2022-05-17T00:00:00Z").getNano());
+        rows.add(row);
+        row = mapper.createArrayNode();
+        row.add(Instant.parse("2022-05-17T00:00:00.1Z").getNano());
+        rows.add(row);
+        row = mapper.createArrayNode();
+        row.add(Instant.parse("2022-05-17T00:00:00.12Z").getNano());
+        rows.add(row);
+        row = mapper.createArrayNode();
+        row.add(Instant.parse("2022-05-17T00:00:00.123Z").getNano());
+        rows.add(row);
+        row = mapper.createArrayNode();
+        row.add(Instant.parse("2022-05-17T00:00:00.1234Z").getNano());
+        rows.add(row);
+        row = mapper.createArrayNode();
+        row.add(Instant.parse("2022-05-17T00:00:00.12345Z").getNano());
+        rows.add(row);
+        row = mapper.createArrayNode();
+        row.add(Instant.parse("2022-05-17T00:00:00.123456Z").getNano());
+        rows.add(row);
+        row = mapper.createArrayNode();
+        row.add(Instant.parse("2022-05-17T00:00:00.1234567Z").getNano());
+        rows.add(row);
+        row = mapper.createArrayNode();
+        row.add(Instant.parse("2022-05-17T00:00:00.12345678Z").getNano());
+        rows.add(row);
+        row = mapper.createArrayNode();
+        row.add(Instant.parse("2022-05-17T00:00:00.123456789Z").getNano());
+        rows.add(row);
 
         String columns = "[ { \"ColumnName\": \"a\", \"ColumnType\": \"datetime\" } ]";
-        KustoResultSetTable res = new KustoResultSetTable(new JSONObject("{\"TableName\":\"Table_0\"," +
+        KustoResultSetTable res = new KustoResultSetTable(mapper.createArrayNode().add("{\"TableName\":\"Table_0\"," +
                 "\"Columns\":" + columns + ",\"Rows\":" +
-                rows.toString() + "}"));
+                rows + "}"));
 
         Integer rowNum = 0;
         while (res.next()) {
             Assertions.assertEquals(
-                    LocalDateTime.ofInstant((Instant) ((JSONArray) rows.get(rowNum)).get(0), ZoneOffset.UTC),
-                    res.getKustoDateTime(0));
+                    LocalDateTime.parse(rows.get(rowNum).get(0).toString(),dateTimeFormatter).getNano(),
+                    res.getKustoDateTime(0).getNano());
             rowNum++;
         }
     }

--- a/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
@@ -1,6 +1,5 @@
 package com.microsoft.azure.kusto.data;
 
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.junit.jupiter.api.Assertions;
@@ -57,7 +56,7 @@ public class KustoDateTimeTest {
         Integer rowNum = 0;
         while (res.next()) {
             Assertions.assertEquals(
-                    LocalDateTime.parse(rows.get(rowNum).get(0).toString(),dateTimeFormatter).getNano(),
+                    LocalDateTime.parse(rows.get(rowNum).get(0).toString(), dateTimeFormatter).getNano(),
                     res.getKustoDateTime(0).getNano());
             rowNum++;
         }

--- a/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
@@ -16,7 +16,7 @@ public class KustoDateTimeTest {
     private ObjectMapper mapper = null;
 
     @BeforeEach
-    void setup(){
+    void setup() {
     }
 
     @Test

--- a/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
@@ -3,7 +3,6 @@ package com.microsoft.azure.kusto.data;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
@@ -13,11 +12,6 @@ import java.time.format.DateTimeFormatterBuilder;
 
 public class KustoDateTimeTest {
 
-    private ObjectMapper mapper = null;
-
-    @BeforeEach
-    void setup() {
-    }
 
     @Test
     void KustoResultSet() throws Exception {

--- a/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
@@ -3,49 +3,57 @@ package com.microsoft.azure.kusto.data;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoField;
+import java.time.format.DateTimeFormatterBuilder;
 
 public class KustoDateTimeTest {
+
+    private ObjectMapper mapper = null;
+
+    @BeforeEach
+    void setup(){
+    }
+
     @Test
     void KustoResultSet() throws Exception {
-        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ");
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = Utils.getObjectMapper();
+        DateTimeFormatter kustoDateTimeFormatter = new DateTimeFormatterBuilder().parseCaseInsensitive()
+                .append(DateTimeFormatter.ISO_LOCAL_DATE_TIME).appendLiteral('Z').toFormatter();
         ArrayNode rows = mapper.createArrayNode();
         ArrayNode row = mapper.createArrayNode();
-        row.add(Instant.parse("2022-05-17T00:00:00Z").getNano());
+        row.add(Instant.parse("2022-05-17T00:00:00Z").toString());
         rows.add(row);
         row = mapper.createArrayNode();
-        row.add(Instant.parse("2022-05-17T00:00:00.1Z").getNano());
+        row.add(Instant.parse("2022-05-17T00:00:00.1Z").toString());
         rows.add(row);
         row = mapper.createArrayNode();
-        row.add(Instant.parse("2022-05-17T00:00:00.12Z").getNano());
+        row.add(Instant.parse("2022-05-17T00:00:00.12Z").toString());
         rows.add(row);
         row = mapper.createArrayNode();
-        row.add(Instant.parse("2022-05-17T00:00:00.123Z").getNano());
+        row.add(Instant.parse("2022-05-17T00:00:00.123Z").toString());
         rows.add(row);
         row = mapper.createArrayNode();
-        row.add(Instant.parse("2022-05-17T00:00:00.1234Z").getNano());
+        row.add(Instant.parse("2022-05-17T00:00:00.1234Z").toString());
         rows.add(row);
         row = mapper.createArrayNode();
-        row.add(Instant.parse("2022-05-17T00:00:00.12345Z").getNano());
+        row.add(Instant.parse("2022-05-17T00:00:00.12345Z").toString());
         rows.add(row);
         row = mapper.createArrayNode();
-        row.add(Instant.parse("2022-05-17T00:00:00.123456Z").getNano());
+        row.add(Instant.parse("2022-05-17T00:00:00.123456Z").toString());
         rows.add(row);
         row = mapper.createArrayNode();
-        row.add(Instant.parse("2022-05-17T00:00:00.1234567Z").getNano());
+        row.add(Instant.parse("2022-05-17T00:00:00.1234567Z").toString());
         rows.add(row);
         row = mapper.createArrayNode();
-        row.add(Instant.parse("2022-05-17T00:00:00.12345678Z").getNano());
+        row.add(Instant.parse("2022-05-17T00:00:00.12345678Z").toString());
         rows.add(row);
         row = mapper.createArrayNode();
-        row.add(Instant.parse("2022-05-17T00:00:00.123456789Z").getNano());
+        row.add(Instant.parse("2022-05-17T00:00:00.123456789Z").toString());
         rows.add(row);
 
         String columns = "[ { \"ColumnName\": \"a\", \"ColumnType\": \"datetime\" } ]";
@@ -56,8 +64,8 @@ public class KustoDateTimeTest {
         Integer rowNum = 0;
         while (res.next()) {
             Assertions.assertEquals(
-                    LocalDateTime.parse(rows.get(rowNum).get(0).toString(), dateTimeFormatter).getNano(),
-                    res.getKustoDateTime(0).getNano());
+                    LocalDateTime.parse(rows.get(rowNum).get(0).toString(), kustoDateTimeFormatter),
+                    res.getKustoDateTime(0));
             rowNum++;
         }
     }

--- a/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/KustoDateTimeTest.java
@@ -12,7 +12,6 @@ import java.time.format.DateTimeFormatterBuilder;
 
 public class KustoDateTimeTest {
 
-
     @Test
     void KustoResultSet() throws Exception {
         ObjectMapper mapper = Utils.getObjectMapper();

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
@@ -1,7 +1,9 @@
 package com.microsoft.azure.kusto.data;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -22,22 +24,24 @@ import java.util.UUID;
 public class ResultSetTest {
     @Test
     void KustoResultSet() throws Exception {
-        JSONArray rows = new JSONArray();
-        JSONArray row1 = new JSONArray();
-        JSONArray row2 = new JSONArray();
-        JSONObject nullObj = null;
-        row2.put(nullObj);
-        row2.put("");
-        row2.put(nullObj);
-        row2.put(nullObj);
-        row2.put(nullObj);
-        row2.put(nullObj);
-        row2.put(nullObj);
-        row2.put(nullObj);
-        row2.put(nullObj);
-        row2.put(nullObj);
-        row2.put(nullObj);
-        rows.put(row2);
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        ArrayNode rows = objectMapper.createArrayNode();
+        ArrayNode row1 = objectMapper.createArrayNode();
+        ArrayNode row2 = objectMapper.createArrayNode();
+        JsonNode nullObj = null;
+        row2.add(nullObj);
+        row2.add("");
+        row2.add(nullObj);
+        row2.add(nullObj);
+        row2.add(nullObj);
+        row2.add(nullObj);
+        row2.add(nullObj);
+        row2.add(nullObj);
+        row2.add(nullObj);
+        row2.add(nullObj);
+        row2.add(nullObj);
+        rows.add(row2);
 
         String str = "str";
         Instant now = Instant.now();
@@ -50,18 +54,18 @@ public class ResultSetTest {
         double d = 1.1d;
         short s1 = 10;
         String durationAsKustoString = LocalTime.MIDNIGHT.plus(duration).toString();
-        row1.put(true);
-        row1.put(str);
-        row1.put(now);
-        row1.put(dec);
-        row1.put(new JSONObject());
-        row1.put(uuid);
-        row1.put(i);
-        row1.put(l);
-        row1.put(BigDecimal.valueOf(d));
-        row1.put(durationAsKustoString);
-        row1.put(s1);
-        rows.put(row1);
+        row1.add(true);
+        row1.add(str);
+        row1.add(now.getNano());
+        row1.add(dec);
+        row1.add(objectMapper.createArrayNode());
+        row1.add(uuid.toString());
+        row1.add(i);
+        row1.add(l);
+        row1.add(BigDecimal.valueOf(d));
+        row1.add(durationAsKustoString);
+        row1.add(s1);
+        rows.add(row1);
 
         String columns = "[ { \"ColumnName\": \"a\", \"ColumnType\": \"bool\" }, { \"ColumnName\": \"b\", " +
                 "\"ColumnType\": \"string\" }, { \"ColumnName\": \"c\", \"ColumnType\": \"datetime\" }, { " +
@@ -70,9 +74,9 @@ public class ResultSetTest {
                 "\"ColumnName\": \"g\", \"ColumnType\": \"int\" }, { \"ColumnName\": \"h\", \"ColumnType\": " +
                 "\"long\" }, { \"ColumnName\": \"i\", \"ColumnType\": \"real\" }, { \"ColumnName\": \"j\", " +
                 "\"ColumnType\": \"timespan\" },{ \"ColumnName\": \"k\", \"ColumnType\": \"short\" } ]";
-        KustoResultSetTable res = new KustoResultSetTable(new JSONObject("{\"TableName\":\"Table_0\"," +
+        KustoResultSetTable res = new KustoResultSetTable(objectMapper.readTree("{\"TableName\":\"Table_0\"," +
                 "\"Columns\":" + columns + ",\"Rows\":" +
-                rows.toString() + "}"));
+                rows + "}"));
         res.next();
         assert res.getBooleanObject(0) == null;
         assert res.getString(1).equals("");
@@ -97,7 +101,7 @@ public class ResultSetTest {
         Assertions.assertEquals(sdf.format(new Date(now.getEpochSecond() * 1000)), res.getDate(2).toString());
 
         Assertions.assertEquals(res.getBigDecimal(3), dec);
-        Assertions.assertEquals(res.getJSONObject(4).toString(), new JSONObject().toString());
+        Assertions.assertEquals(res.getJSONObject(4).toString(), objectMapper.createObjectNode().toString());
         Assertions.assertEquals(res.getUUID(5), uuid);
         Assertions.assertEquals(res.getIntegerObject(6), i);
         Assertions.assertEquals(res.getLongObject(7), l);

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
@@ -57,7 +57,7 @@ public class ResultSetTest {
         row1.add(true);
         row1.add(str);
         row1.add(String.valueOf(now));
-        row1.add(String.valueOf(dec));
+        row1.add(dec);
         row1.add(objectMapper.createObjectNode());
         row1.add(String.valueOf(uuid));
         row1.add(i);
@@ -76,7 +76,7 @@ public class ResultSetTest {
                 "\"ColumnType\": \"timespan\" },{ \"ColumnName\": \"k\", \"ColumnType\": \"short\" } ]";
         KustoResultSetTable res = new KustoResultSetTable(objectMapper.readTree("{\"TableName\":\"Table_0\"," +
                 "\"Columns\":" + columns + ",\"Rows\":" +
-                rows.toString() + "}"));
+                rows + "}"));
         res.next();
         assert res.getBooleanObject(0) == null;
         assert res.getString(1).equals("");

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
@@ -56,10 +56,10 @@ public class ResultSetTest {
         String durationAsKustoString = LocalTime.MIDNIGHT.plus(duration).toString();
         row1.add(true);
         row1.add(str);
-        row1.add(now.getNano());
-        row1.add(dec);
-        row1.add(objectMapper.createArrayNode());
-        row1.add(uuid.toString());
+        row1.add(String.valueOf(now));
+        row1.add(String.valueOf(dec));
+        row1.add(objectMapper.createObjectNode());
+        row1.add(String.valueOf(uuid));
         row1.add(i);
         row1.add(l);
         row1.add(BigDecimal.valueOf(d));
@@ -76,7 +76,7 @@ public class ResultSetTest {
                 "\"ColumnType\": \"timespan\" },{ \"ColumnName\": \"k\", \"ColumnType\": \"short\" } ]";
         KustoResultSetTable res = new KustoResultSetTable(objectMapper.readTree("{\"TableName\":\"Table_0\"," +
                 "\"Columns\":" + columns + ",\"Rows\":" +
-                rows + "}"));
+                rows.toString() + "}"));
         res.next();
         assert res.getBooleanObject(0) == null;
         assert res.getString(1).equals("");
@@ -101,7 +101,7 @@ public class ResultSetTest {
         Assertions.assertEquals(sdf.format(new Date(now.getEpochSecond() * 1000)), res.getDate(2).toString());
 
         Assertions.assertEquals(res.getBigDecimal(3), dec);
-        Assertions.assertEquals(res.getJSONObject(4).toString(), objectMapper.createObjectNode().toString());
+        Assertions.assertEquals(res.getJSONObject(4), objectMapper.createObjectNode());
         Assertions.assertEquals(res.getUUID(5), uuid);
         Assertions.assertEquals(res.getIntegerObject(6), i);
         Assertions.assertEquals(res.getLongObject(7), l);

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
@@ -1,11 +1,9 @@
 package com.microsoft.azure.kusto.data;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.microsoft.azure.kusto.data.exceptions.JsonPropertyMissingException;
 import com.microsoft.azure.kusto.data.exceptions.KustoServiceQueryError;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -57,6 +55,8 @@ public class ResultSetTest {
         long l = 100000000000L;
         double d = 1.1d;
         short s1 = 10;
+        float f1 = 15.0f;
+        BigDecimal bigDecimal = new BigDecimal("10.0003214134245341414141314134134101");
         String durationAsKustoString = LocalTime.MIDNIGHT.plus(duration).toString();
         row1.add(true);
         row1.add(str);
@@ -66,9 +66,11 @@ public class ResultSetTest {
         row1.add(String.valueOf(uuid));
         row1.add(i);
         row1.add(l);
-        row1.add(BigDecimal.valueOf(d));
+        row1.add(bigDecimal);
         row1.add(durationAsKustoString);
         row1.add(s1);
+        row1.add(f1);
+        row1.add(d);
         rows.add(row1);
 
         String columns = "[ { \"ColumnName\": \"a\", \"ColumnType\": \"bool\" }, { \"ColumnName\": \"b\", " +
@@ -93,7 +95,7 @@ public class ResultSetTest {
         assert res.getLongObject(7) == null;
         assert res.getDoubleObject(8) == null;
         assert res.getTime(9) == null;
-        assert res.getShortObject(9) == null;
+        assert res.getShortObject(10) == null;
 
         res.next();
         Assertions.assertTrue(res.getBooleanObject(0));
@@ -109,11 +111,13 @@ public class ResultSetTest {
         Assertions.assertEquals(res.getUUID(5), uuid);
         Assertions.assertEquals(res.getIntegerObject(6), i);
         Assertions.assertEquals(res.getLongObject(7), l);
-        Assertions.assertEquals(res.getDoubleObject(8), d);
+        Assertions.assertEquals(res.getBigDecimal(8), bigDecimal);
 
         Assertions.assertEquals(res.getTime(9), Time.valueOf(durationAsKustoString));
         Assertions.assertEquals(res.getLocalTime(9), LocalTime.parse(durationAsKustoString));
         Assertions.assertEquals(res.getShort(10), s1);
+        Assertions.assertEquals(res.getBigDecimal(11), BigDecimal.valueOf(f1));
+        Assertions.assertEquals(res.getBigDecimal(12), BigDecimal.valueOf(d));
 
     }
 

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
@@ -3,7 +3,6 @@ package com.microsoft.azure.kusto.data;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ResultSetTest.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 public class ResultSetTest {
     @Test
     void KustoResultSet() throws Exception {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = Utils.getObjectMapper();
 
         ArrayNode rows = objectMapper.createArrayNode();
         ArrayNode row1 = objectMapper.createArrayNode();

--- a/ingest/pom.xml
+++ b/ingest/pom.xml
@@ -266,5 +266,15 @@
             <artifactId>vavr</artifactId>
             <version>${io.vavr.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>${fasterxml.jackson.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>${fasterxml.jackson.core.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/ingest/pom.xml
+++ b/ingest/pom.xml
@@ -266,15 +266,5 @@
             <artifactId>vavr</artifactId>
             <version>${io.vavr.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${fasterxml.jackson.core.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>${fasterxml.jackson.core.version}</version>
-        </dependency>
     </dependencies>
 </project>

--- a/ingest/pom.xml
+++ b/ingest/pom.xml
@@ -230,11 +230,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>${json.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
             <version>${annotations.version}</version>

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionProperties.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestionProperties.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.kusto.data.Ensure;
+import com.microsoft.azure.kusto.data.Utils;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionClientException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.TextStringBuilder;
@@ -228,13 +229,13 @@ public class IngestionProperties {
                 }
             }
 
-            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectMapper objectMapper = Utils.getObjectMapper();
             String tagsAsJson = objectMapper.writeValueAsString(tags);
             fullAdditionalProperties.put("tags", tagsAsJson);
         }
 
         if (!ingestIfNotExists.isEmpty()) {
-            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectMapper objectMapper = Utils.getObjectMapper();
             String ingestIfNotExistsJson = objectMapper.writeValueAsString(ingestIfNotExists);
             fullAdditionalProperties.put("ingestIfNotExists", ingestIfNotExistsJson);
         }
@@ -247,7 +248,7 @@ public class IngestionProperties {
             fullAdditionalProperties.put("ingestionMappingReference", mappingReference);
             fullAdditionalProperties.put("ingestionMappingType", ingestionMapping.getIngestionMappingKind().getKustoValue());
         } else if (ingestionMapping.getColumnMappings() != null) {
-            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectMapper objectMapper = Utils.getObjectMapper();
             objectMapper.setVisibility(PropertyAccessor.ALL, Visibility.NONE);
             objectMapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
 

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClient.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClient.java
@@ -17,7 +17,6 @@ import com.microsoft.azure.kusto.ingest.source.StreamSourceInfo;
 
 import org.apache.http.client.utils.URIBuilder;
 import org.jetbrains.annotations.Nullable;
-import org.json.JSONException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -250,14 +249,14 @@ public class ManagedStreamingIngestClient implements IngestClient {
                             && e.getCause().getCause() != null
                             && e.getCause().getCause() instanceof DataWebException) {
                         DataWebException webException = (DataWebException) e.getCause().getCause();
-                        try {
+                        //try {
                             OneApiError oneApiError = webException.getApiError();
                             if (oneApiError.isPermanent()) {
                                 throw e;
                             }
-                        } catch (JSONException je) {
-                            log.info("Failed to parse json in exception, continuing.", je);
-                        }
+                        /*} catch (JsonProcessingException je) {
+                            log.error("Failed to parse json in exception, continuing.", je);
+                        }*/
                     }
 
                     log.info(String.format("Streaming ingestion failed attempt %d", currentAttempt), e);

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClient.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClient.java
@@ -249,14 +249,14 @@ public class ManagedStreamingIngestClient implements IngestClient {
                             && e.getCause().getCause() != null
                             && e.getCause().getCause() instanceof DataWebException) {
                         DataWebException webException = (DataWebException) e.getCause().getCause();
-                        //try {
-                            OneApiError oneApiError = webException.getApiError();
-                            if (oneApiError.isPermanent()) {
-                                throw e;
-                            }
-                        /*} catch (JsonProcessingException je) {
-                            log.error("Failed to parse json in exception, continuing.", je);
-                        }*/
+                        // try {
+                        OneApiError oneApiError = webException.getApiError();
+                        if (oneApiError.isPermanent()) {
+                            throw e;
+                        }
+                        /*
+                         * } catch (JsonProcessingException je) { log.error("Failed to parse json in exception, continuing.", je); }
+                         */
                     }
 
                     log.info(String.format("Streaming ingestion failed attempt %d", currentAttempt), e);

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClient.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ManagedStreamingIngestClient.java
@@ -249,14 +249,10 @@ public class ManagedStreamingIngestClient implements IngestClient {
                             && e.getCause().getCause() != null
                             && e.getCause().getCause() instanceof DataWebException) {
                         DataWebException webException = (DataWebException) e.getCause().getCause();
-                        // try {
                         OneApiError oneApiError = webException.getApiError();
                         if (oneApiError.isPermanent()) {
                             throw e;
                         }
-                        /*
-                         * } catch (JsonProcessingException je) { log.error("Failed to parse json in exception, continuing.", je); }
-                         */
                     }
 
                     log.info(String.format("Streaming ingestion failed attempt %d", currentAttempt), e);

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientImpl.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientImpl.java
@@ -4,10 +4,7 @@
 package com.microsoft.azure.kusto.ingest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.microsoft.azure.kusto.data.Client;
-import com.microsoft.azure.kusto.data.ClientFactory;
-import com.microsoft.azure.kusto.data.Ensure;
-import com.microsoft.azure.kusto.data.HttpClientProperties;
+import com.microsoft.azure.kusto.data.*;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionClientException;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException;
@@ -145,7 +142,7 @@ public class QueuedIngestClientImpl extends IngestClientBase implements QueuedIn
                 tableStatuses.add(ingestionBlobInfo.getIngestionStatusInTable());
             }
 
-            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectMapper objectMapper = Utils.getObjectMapper();
             String serializedIngestionBlobInfo = objectMapper.writeValueAsString(ingestionBlobInfo);
 
             azureStorageClient.postMessageToQueue(

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
@@ -232,7 +232,7 @@ class E2ETest {
                     JsonNode primaryResult = null;
                     assert jsonArray != null;
                     for (JsonNode o : jsonArray) {
-                        if (o.toString() != null && o.toString().matches(".*\"TableKind\"\\s*:\\s*\"PrimaryResult\".*")) {
+                        if (o != null && o.toString().matches(".*\"TableKind\"\\s*:\\s*\"PrimaryResult\".*")) {
                             primaryResult = new ObjectMapper().readTree(o.toString());
                             break;
                         }

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
@@ -228,7 +228,7 @@ class E2ETest {
                 if (checkViaJson) {
                     String result = queryClient.executeToJsonResult(databaseName, String.format("%s | count", tableName));
                     JsonNode jsonNode = new ObjectMapper().readTree(result);
-                    ArrayNode jsonArray = jsonNode.isArray()? (ArrayNode) jsonNode : null;
+                    ArrayNode jsonArray = jsonNode.isArray() ? (ArrayNode) jsonNode : null;
                     JsonNode primaryResult = null;
                     assert jsonArray != null;
                     for (JsonNode o : jsonArray) {

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ResourceManagerTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ResourceManagerTest.java
@@ -137,7 +137,7 @@ class ResourceManagerTest {
     }
 
     static KustoOperationResult generateIngestionAuthTokenResult() throws KustoServiceQueryError, IOException {
-        ObjectMapper objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = Utils.getObjectMapper();
         List<List<String>> valuesList = new ArrayList<>();
         valuesList.add(new ArrayList<>((Collections.singletonList(AUTH_TOKEN))));
         String listAsJson = objectMapper.writeValueAsString(valuesList);

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ResourceManagerTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ResourceManagerTest.java
@@ -11,7 +11,6 @@ import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
 import com.microsoft.azure.kusto.data.exceptions.KustoServiceQueryError;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionClientException;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException;
-import org.json.JSONException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -21,8 +20,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -41,7 +38,7 @@ class ResourceManagerTest {
     private static final String SUCCESS_QUEUE = "successQueue";
 
     @BeforeAll
-    static void setUp() throws DataClientException, DataServiceException, JSONException, KustoServiceQueryError, IOException {
+    static void setUp() throws DataClientException, DataServiceException, KustoServiceQueryError, IOException {
         when(clientMock.execute(Commands.INGESTION_RESOURCES_SHOW_COMMAND))
                 .thenReturn(generateIngestionResourcesResult());
 
@@ -119,7 +116,7 @@ class ResourceManagerTest {
                 resourceManager.getIngestionResource(ResourceManager.ResourceType.SUCCESSFUL_INGESTIONS_QUEUE));
     }
 
-    static KustoOperationResult generateIngestionResourcesResult() throws JSONException, KustoServiceQueryError, IOException {
+    static KustoOperationResult generateIngestionResourcesResult() throws KustoServiceQueryError, IOException {
         List<List<String>> valuesList = new ArrayList<>();
         valuesList.add(new ArrayList<>((Arrays.asList("SecuredReadyForAggregationQueue", QUEUE_1))));
         valuesList.add(new ArrayList<>((Arrays.asList("SecuredReadyForAggregationQueue", QUEUE_2))));
@@ -137,7 +134,7 @@ class ResourceManagerTest {
         return new KustoOperationResult(response, "v1");
     }
 
-    static KustoOperationResult generateIngestionAuthTokenResult() throws JSONException, KustoServiceQueryError, IOException {
+    static KustoOperationResult generateIngestionAuthTokenResult() throws KustoServiceQueryError, IOException {
         List<List<String>> valuesList = new ArrayList<>();
         valuesList.add(new ArrayList<>((Collections.singletonList(AUTH_TOKEN))));
         String listAsJson = new ObjectMapper().writeValueAsString(valuesList);

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ResourceManagerTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ResourceManagerTest.java
@@ -6,6 +6,7 @@ package com.microsoft.azure.kusto.ingest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.kusto.data.Client;
 import com.microsoft.azure.kusto.data.KustoOperationResult;
+import com.microsoft.azure.kusto.data.Utils;
 import com.microsoft.azure.kusto.data.exceptions.DataClientException;
 import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
 import com.microsoft.azure.kusto.data.exceptions.KustoServiceQueryError;
@@ -117,6 +118,7 @@ class ResourceManagerTest {
     }
 
     static KustoOperationResult generateIngestionResourcesResult() throws KustoServiceQueryError, IOException {
+        ObjectMapper objectMapper = Utils.getObjectMapper();
         List<List<String>> valuesList = new ArrayList<>();
         valuesList.add(new ArrayList<>((Arrays.asList("SecuredReadyForAggregationQueue", QUEUE_1))));
         valuesList.add(new ArrayList<>((Arrays.asList("SecuredReadyForAggregationQueue", QUEUE_2))));
@@ -125,7 +127,7 @@ class ResourceManagerTest {
         valuesList.add(new ArrayList<>((Arrays.asList("TempStorage", STORAGE_1))));
         valuesList.add(new ArrayList<>((Arrays.asList("TempStorage", STORAGE_2))));
         valuesList.add(new ArrayList<>((Arrays.asList("IngestionsStatusTable", STATUS_TABLE))));
-        String listAsJson = new ObjectMapper().writeValueAsString(valuesList);
+        String listAsJson = objectMapper.writeValueAsString(valuesList);
         String response = "{\"Tables\":[{\"TableName\":\"Table_0\",\"Columns\":[{\"ColumnName\":\"ResourceTypeName\"," +
                 "\"DataType\":\"String\",\"ColumnType\":\"string\"},{\"ColumnName\":\"StorageRoot\",\"DataType\":" +
                 "\"String\",\"ColumnType\":\"string\"}],\"Rows\":"
@@ -135,9 +137,10 @@ class ResourceManagerTest {
     }
 
     static KustoOperationResult generateIngestionAuthTokenResult() throws KustoServiceQueryError, IOException {
+        ObjectMapper objectMapper = new ObjectMapper();
         List<List<String>> valuesList = new ArrayList<>();
         valuesList.add(new ArrayList<>((Collections.singletonList(AUTH_TOKEN))));
-        String listAsJson = new ObjectMapper().writeValueAsString(valuesList);
+        String listAsJson = objectMapper.writeValueAsString(valuesList);
 
         String response = "{\"Tables\":[{\"TableName\":\"Table_0\",\"Columns\":[{\"ColumnName\":\"AuthorizationContext\",\"DataType\":\"String\",\"ColumnType\":\"string\"}],\"Rows\":"
                 +

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,7 @@
         <msal4j.version>1.11.0</msal4j.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
-        <json.version>20201115</json.version>
-        <fasterxml.jackson.core.version>2.12.5</fasterxml.jackson.core.version>
+        <fasterxml.jackson.core.version>2.13.4</fasterxml.jackson.core.version>
         <azure-storage.version>8.6.6</azure-storage.version>
         <azure-identity.version>1.3.7</azure-identity.version> <!-- Do not use 1.4.1, as it has a showstopping bug for us. Any version that includes https://github.com/Azure/azure-sdk-for-java/pull/25580 is OK -->
         <azure-core.version>1.21.0</azure-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <msal4j.version>1.11.0</msal4j.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.15</httpcore.version>
-        <fasterxml.jackson.core.version>2.13.4</fasterxml.jackson.core.version>
+        <fasterxml.jackson.core.version>2.13.3</fasterxml.jackson.core.version>
         <azure-storage.version>8.6.6</azure-storage.version>
         <azure-identity.version>1.3.7</azure-identity.version> <!-- Do not use 1.4.1, as it has a showstopping bug for us. Any version that includes https://github.com/Azure/azure-sdk-for-java/pull/25580 is OK -->
         <azure-core.version>1.21.0</azure-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </developers>
 
     <properties>
-        <revision>3.1.3</revision> <!-- CHANGE THIS to adjust project version-->
+        <revision>3.1.4</revision> <!-- CHANGE THIS to adjust project version-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
 

--- a/quickstart/kusto_sample_config.json
+++ b/quickstart/kusto_sample_config.json
@@ -9,6 +9,7 @@
   "ingestData": true,
   "authenticationMode": "UserPrompt",
   "waitForUser": true,
+  "ignoreFirstRecord": false,
   "waitForIngestSeconds": 20,
   "batchingPolicy": "{ 'MaximumBatchingTimeSpan': '00:00:10', 'MaximumNumberOfItems': 500, 'MaximumRawDataSizeMB': 1024 }",
   "tableSchema": "(rownumber:int, rowguid:string, xdouble:real, xfloat:real, xbool:bool, xint16:int, xint32:int, xint64:long, xuint8:long, xuint16:long, xuint32:long, xuint64:long, xdate:datetime, xsmalltext:string, xtext:string, xnumberAsText:string, xtime:timespan, xtextWithNulls:string, xdynamicWithNulls:dynamic)",

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -125,10 +125,5 @@
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.json</groupId>
-            <artifactId>json</artifactId>
-            <version>${json.version}</version>
-        </dependency>
     </dependencies>
 </project>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -33,7 +33,7 @@
     </developers>
 
     <properties>
-        <revision>3.1.3</revision> <!-- CHANGE THIS to match project version in the root (not technically parent) pom -->
+        <revision>3.1.4</revision> <!-- CHANGE THIS to match project version in the root (not technically parent) pom -->
         <java.version>1.8</java.version>
         <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>

--- a/quickstart/src/main/java/com/microsoft/azure/kusto/quickstart/SampleApp.java
+++ b/quickstart/src/main/java/com/microsoft/azure/kusto/quickstart/SampleApp.java
@@ -308,7 +308,7 @@ public class SampleApp {
     private static ConfigJson loadConfigs() {
         File configFile = new File(".\\" + SampleApp.configFileName);
         try {
-            ObjectMapper mapper = new ObjectMapper();
+            ObjectMapper mapper = com.microsoft.azure.kusto.data.Utils.getObjectMapper();
             mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true);
             return mapper.readValue(configFile, ConfigJson.class);
 

--- a/quickstart/src/main/java/com/microsoft/azure/kusto/quickstart/Utils.java
+++ b/quickstart/src/main/java/com/microsoft/azure/kusto/quickstart/Utils.java
@@ -192,15 +192,16 @@ public class Utils {
         /**
          * Creates a fitting KustoIngestionProperties object, to be used when executing ingestion commands
          *
-         * @param databaseName DB name
-         * @param tableName    Table name
-         * @param dataFormat   Given data format
-         * @param mappingName  Desired mapping name
+         * @param databaseName      DB name
+         * @param tableName         Table name
+         * @param dataFormat        Given data format
+         * @param mappingName       Desired mapping name
+         * @param ignoreFirstRecord Flag noting whether to ignore the first record in the table
          * @return KustoIngestionProperties object
          */
         @NotNull
         protected static IngestionProperties createIngestionProperties(String databaseName, String tableName, IngestionProperties.DataFormat dataFormat,
-                String mappingName) {
+                String mappingName, boolean ignoreFirstRecord) {
             IngestionProperties ingestionProperties = new IngestionProperties(databaseName, tableName);
             ingestionProperties.setDataFormat(dataFormat);
             // Learn More: For more information about supported data formats, see: https://docs.microsoft.com/azure/data-explorer/ingestion-supported-formats
@@ -212,6 +213,7 @@ public class Utils {
             // We therefore set Flush-Immediately for the sake of the sample, but it generally shouldn't be used in practice.
             // Comment out the line below after running the sample the first few times.
             ingestionProperties.setFlushImmediately(true);
+            ingestionProperties.setIgnoreFirstRecord(ignoreFirstRecord);
 
             return ingestionProperties;
         }
@@ -219,16 +221,17 @@ public class Utils {
         /**
          * Ingest Data from a given file path
          *
-         * @param ingestClient Client to ingest data
-         * @param databaseName DB name
-         * @param tableName    Table name
-         * @param filePath     File path
-         * @param dataFormat   Given data format
-         * @param mappingName  Desired mapping name
+         * @param ingestClient      Client to ingest data
+         * @param databaseName      DB name
+         * @param tableName         Table name
+         * @param filePath          File path
+         * @param dataFormat        Given data format
+         * @param mappingName       Desired mapping name
+         * @param ignoreFirstRecord Flag noting whether to ignore the first record in the table
          */
         protected static void ingestFromFile(IngestClient ingestClient, String databaseName, String tableName, String filePath,
-                IngestionProperties.DataFormat dataFormat, String mappingName) {
-            IngestionProperties ingestionProperties = createIngestionProperties(databaseName, tableName, dataFormat, mappingName);
+                IngestionProperties.DataFormat dataFormat, String mappingName, boolean ignoreFirstRecord) {
+            IngestionProperties ingestionProperties = createIngestionProperties(databaseName, tableName, dataFormat, mappingName, ignoreFirstRecord);
 
             // Tip 1: For optimal ingestion batching and performance, specify the uncompressed data size in the file descriptor (e.g. fileToIngest.length())
             // instead of the default below of 0.
@@ -250,16 +253,17 @@ public class Utils {
         /**
          * Ingest Data from a given file path
          *
-         * @param ingestClient Client to ingest data
-         * @param databaseName DB name
-         * @param tableName    Table name
-         * @param blobUrl      Blob Url
-         * @param dataFormat   Given data format
-         * @param mappingName  Desired mapping name
+         * @param ingestClient      Client to ingest data
+         * @param databaseName      DB name
+         * @param tableName         Table name
+         * @param blobUrl           Blob Url
+         * @param dataFormat        Given data format
+         * @param mappingName       Desired mapping name
+         * @param ignoreFirstRecord Flag noting whether to ignore the first record in the table
          */
         protected static void ingestFromBlob(IngestClient ingestClient, String databaseName, String tableName, String blobUrl,
-                IngestionProperties.DataFormat dataFormat, String mappingName) {
-            IngestionProperties ingestionProperties = createIngestionProperties(databaseName, tableName, dataFormat, mappingName);
+                IngestionProperties.DataFormat dataFormat, String mappingName, boolean ignoreFirstRecord) {
+            IngestionProperties ingestionProperties = createIngestionProperties(databaseName, tableName, dataFormat, mappingName, ignoreFirstRecord);
 
             // Tip 1: For optimal ingestion batching and performance,specify the uncompressed data size in the file descriptor instead of the default below of 0
             // Otherwise, the service will determine the file size, requiring an additional s2s call and may not be accurate for compressed files.

--- a/samples/src/main/java/TableStatus.java
+++ b/samples/src/main/java/TableStatus.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.microsoft.azure.kusto.data.Utils;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
 import com.microsoft.azure.kusto.ingest.IngestClient;
 import com.microsoft.azure.kusto.ingest.IngestClientFactory;
@@ -44,7 +45,7 @@ public class TableStatus {
                 statuses = ingestionResult.getIngestionStatusCollection();
             }
 
-            ObjectMapper objectMapper = new ObjectMapper();
+            ObjectMapper objectMapper = Utils.getObjectMapper();
             String resultAsJson = objectMapper.writeValueAsString(statuses.get(0));
             System.out.println(resultAsJson);
         } catch (Exception e) {


### PR DESCRIPTION
#### Pull Request Description

org.json:json is used for json parsing and reading capabilities

But org.json:json uses a non-free JSON license, which has already been banned by

[Apache Software Foundation](https://www.apache.org/legal/resolved.html#category-x).
[Debian](https://wiki.debian.org/qa.debian.org/jsonevil)

Hence org.json dependency is enforced as banned dependency in apache-nifi base pom.xml.

Considering this org.json needs to be removed and replaced with com.fasterxml.jackson

---

#### Future Release Comment
_[Add description of your change, to include in the next release]_
_[Delete any or all irrelevant sections, e.g. if your change does not warrant a release comment at all]_

**Breaking Changes:**
- Due to datatype changes, there can be an impact 

**Features:**
- None

**Fixes:**
- None
