### PR TITLE
Fixed java wrapper for http props

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/HttpClientWrapper.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/HttpClientWrapper.java
@@ -152,7 +152,7 @@ public class HttpClientWrapper implements com.azure.core.http.HttpClient, IHttpC
         }
         // Translating the headers
 
-        request.setHeaders(httpRequest.headers().entrySet().stream().map(h -> new BasicHeader(h.getKey(), h.getValue())).toArray(Header[]::new));
+        request.setHeaders(httpRequest.headers().entrySet().stream().filter(h -> isNotContentLength(h.getKey())).map(h -> new BasicHeader(h.getKey(), h.getValue())).toArray(Header[]::new));
 
         // Setting the request's body/entity
         if (request instanceof HttpEntityEnclosingRequest) {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/HttpClientWrapper.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/HttpClientWrapper.java
@@ -74,7 +74,8 @@ public class HttpClientWrapper implements com.azure.core.http.HttpClient, IHttpC
         }
         // Translating the headers
 
-        request.setHeaders(httpRequest.getHeaders().stream().filter(h -> isNotContentLength(h.getName())).map(h -> new BasicHeader(h.getName(), h.getValue())).toArray(Header[]::new));
+        request.setHeaders(httpRequest.getHeaders().stream().filter(h -> isNotContentLength(h.getName())).map(h -> new BasicHeader(h.getName(), h.getValue()))
+                .toArray(Header[]::new));
 
         // Setting the request's body/entity
 
@@ -91,20 +92,19 @@ public class HttpClientWrapper implements com.azure.core.http.HttpClient, IHttpC
 
             EXECUTOR.execute(() -> {
                 httpRequest.getBody().publishOn(Schedulers.boundedElastic()).map(buf -> {
-                            try {
-                                if (buf.hasArray()) {
-                                    osPipe.write(buf.array(), buf.position(), buf.remaining());
-                                } else {
-                                    byte[] bytes = new byte[buf.remaining()];
-                                    buf.get(bytes);
-                                    osPipe.write(bytes);
-                                }
-                            } catch (IOException e) {
-                                return false;
-                            }
-                            return true;
+                    try {
+                        if (buf.hasArray()) {
+                            osPipe.write(buf.array(), buf.position(), buf.remaining());
+                        } else {
+                            byte[] bytes = new byte[buf.remaining()];
+                            buf.get(bytes);
+                            osPipe.write(bytes);
                         }
-                ).blockLast();
+                    } catch (IOException e) {
+                        return false;
+                    }
+                    return true;
+                }).blockLast();
                 try {
                     osPipe.close();
                 } catch (IOException e) {
@@ -114,7 +114,8 @@ public class HttpClientWrapper implements com.azure.core.http.HttpClient, IHttpC
 
             String contentLength = httpRequest.getHeaders().getValue("Content-Length");
             String contentType = httpRequest.getHeaders().getValue("Content-Type");
-            entityEnclosingRequest.setEntity(new InputStreamEntity(isPipe, contentLength == null ? -1 : Long.parseLong(contentLength), contentType == null ? null : ContentType.parse(contentType)));
+            entityEnclosingRequest.setEntity(new InputStreamEntity(isPipe, contentLength == null ? -1 : Long.parseLong(contentLength),
+                    contentType == null ? null : ContentType.parse(contentType)));
         }
 
         // The types of the Monos are different, but we ignore the results anyway (since we only care about the input stream) so this is fine.
@@ -152,7 +153,8 @@ public class HttpClientWrapper implements com.azure.core.http.HttpClient, IHttpC
         }
         // Translating the headers
 
-        request.setHeaders(httpRequest.headers().entrySet().stream().filter(h -> isNotContentLength(h.getKey())).map(h -> new BasicHeader(h.getKey(), h.getValue())).toArray(Header[]::new));
+        request.setHeaders(httpRequest.headers().entrySet().stream().filter(h -> isNotContentLength(h.getKey()))
+                .map(h -> new BasicHeader(h.getKey(), h.getValue())).toArray(Header[]::new));
 
         // Setting the request's body/entity
         if (request instanceof HttpEntityEnclosingRequest) {

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/HttpResponseWrapper.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/HttpResponseWrapper.java
@@ -49,7 +49,8 @@ public class HttpResponseWrapper extends HttpResponse implements IHttpResponse {
 
     @Override
     public String getHeaderValue(String s) {
-        return response.getFirstHeader(s).getValue();
+        Header firstHeader = response.getFirstHeader(s);
+        return firstHeader != null ? firstHeader.getValue() : null;
     }
 
     @Override

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
@@ -99,7 +99,13 @@ class E2ETest {
                 tenantId);
         dmCsb.setUserNameForTracing("testUser");
         try {
-            ingestClient = IngestClientFactory.createClient(dmCsb);
+            ingestClient = IngestClientFactory.createClient(dmCsb, HttpClientProperties.builder()
+                    .keepAlive(true)
+                    .maxKeepAliveTime(120)
+                    .maxIdleTime(60)
+                    .maxConnectionsPerRoute(50)
+                    .maxConnectionsTotal(50)
+                    .build());
         } catch (URISyntaxException ex) {
             Assertions.fail("Failed to create ingest client", ex);
         }


### PR DESCRIPTION
1. Don't set the content-length header for apache http client
2. Moved the body copying to a blocking operation on a new threadpool, to avoid issues with blocking calls in async methods
3. Added content-length and content-type to copied pipe
4. Fixed NRE
5. Tests use the proxied client, to make sure it runs.

Fixes  #282 