### PR TITLE
Dependency bumps, jackson, commons features, httpclient, and msal4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,18 +41,18 @@
         <!-- Versions below are for several dependencies we're using in the data & ingest modules -->
         <!-- Compile dependencies -->
         <slf4j.version>1.8.0-beta4</slf4j.version>
-        <commons-lang3.version>3.11</commons-lang3.version>
+        <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-text.version>1.10.0</commons-text.version>
-        <msal4j.version>1.12.0</msal4j.version>
-        <httpclient.version>4.5.13</httpclient.version>
-        <httpcore.version>4.4.15</httpcore.version>
-        <fasterxml.jackson.core.version>2.13.3</fasterxml.jackson.core.version>
+        <msal4j.version>1.13.7</msal4j.version>
+        <httpclient.version>4.5.14</httpclient.version>
+        <httpcore.version>4.4.16</httpcore.version>
+        <fasterxml.jackson.core.version>2.14.2</fasterxml.jackson.core.version>
         <reactor-core.version>3.4.19</reactor-core.version>
         <univocity-parsers.version>2.9.1</univocity-parsers.version>
         <resilience4j.version>1.7.1</resilience4j.version>
         <io.vavr.version>0.10.2</io.vavr.version>
         <!-- Test dependencies -->
-        <bouncycastle.version>1.68</bouncycastle.version>
+        <bouncycastle.version>1.70</bouncycastle.version>
         <jsonassert.version>1.5.0</jsonassert.version>
         <sqlite-jdbc.version>3.36.0.2</sqlite-jdbc.version>
         <annotations.version>22.0.0</annotations.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <azure-bom-version>1.2.4</azure-bom-version>
 
         <!-- Versions below are for several dependencies we're using in the data & ingest modules -->
+        <!-- Ideally, versions below should align with latest databricks runtime dependency versions -->
         <!-- Compile dependencies -->
         <slf4j.version>1.8.0-beta4</slf4j.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>


### PR DESCRIPTION
changed some minor dependency versions to get rid of some CVEs and Intellij warnings.
ran all tests, everything but E2E passes (E2E did not pass without modification to the main kusto branch either, error was the same in both scenarios)