### PR TITLE
makes AbstractSourceInfo.java public for use in bounded generic methods. Resolves #294

### DIFF
--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/source/AbstractSourceInfo.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/source/AbstractSourceInfo.java
@@ -5,7 +5,7 @@ package com.microsoft.azure.kusto.ingest.source;
 
 import java.util.UUID;
 
-abstract class AbstractSourceInfo implements SourceInfo {
+public abstract class AbstractSourceInfo implements SourceInfo {
 
     private UUID sourceId;
 


### PR DESCRIPTION
Makes AbstractSourceInfo.java public for use in bounded generic methods.

Example:

`
public <T extends AbstractSourceInfo> ingest(T sourceInfo, IngestionProperties props) {
    if (sourceInfo instanceof FileSourceInfo.class) {
       // etc...
    }
}
`
