### PR TITLE
Add the new Storage exceptions to methods signatures

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
@@ -203,7 +203,7 @@ public class Utils {
                     }
                 } catch (JsonProcessingException e) {
                     // It's not ideal to use an exception here for control flow, but we can't know if it's a valid JSON until we try to parse it
-                    LOGGER.debug("json processing error happened while parsing errorFromResponse {} {}" + e.getMessage(), e);
+                    LOGGER.debug("json processing error happened while parsing errorFromResponse {}" + e.getMessage(), e);
                 }
             } else {
                 message = String.format("Http StatusCode='%s'", httpResponse.getStatusLine().toString());

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/AzureStorageClient.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/AzureStorageClient.java
@@ -46,7 +46,7 @@ class AzureStorageClient {
 
     public void azureTableInsertEntity(TableClient tableClient, TableEntity tableEntity) throws URISyntaxException, TableServiceErrorException {
         Ensure.argIsNotNull(tableClient, "tableClient");
-        Ensure.argIsNotNull(tableClient, "tableEntity");
+        Ensure.argIsNotNull(tableEntity, "tableEntity");
 
         tableClient.createEntity(tableEntity);
     }

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/AzureStorageClient.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/AzureStorageClient.java
@@ -5,10 +5,13 @@ package com.microsoft.azure.kusto.ingest;
 
 import com.azure.core.util.BinaryData;
 import com.azure.data.tables.TableClient;
+import com.azure.data.tables.implementation.models.TableServiceErrorException;
 import com.azure.data.tables.models.TableEntity;
 import com.azure.storage.blob.BlobClient;
 import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.queue.QueueClient;
+import com.azure.storage.queue.models.QueueStorageException;
 import com.microsoft.azure.kusto.data.Ensure;
 
 import org.apache.commons.codec.binary.Base64;
@@ -32,7 +35,7 @@ class AzureStorageClient {
     public AzureStorageClient() {
     }
 
-    void postMessageToQueue(QueueClient queueClient, String content) {
+    void postMessageToQueue(QueueClient queueClient, String content) throws QueueStorageException {
         // Ensure
         Ensure.argIsNotNull(queueClient, "queueClient");
         Ensure.stringIsNotBlank(content, "content");
@@ -41,15 +44,15 @@ class AzureStorageClient {
         queueClient.sendMessage(BinaryData.fromBytes(bytesEncoded));
     }
 
-    public void azureTableInsertEntity(TableClient tableClient, TableEntity tableEntity) throws URISyntaxException {
+    public void azureTableInsertEntity(TableClient tableClient, TableEntity tableEntity) throws URISyntaxException, TableServiceErrorException {
         Ensure.argIsNotNull(tableClient, "tableClient");
-        Ensure.argIsNotNull(tableEntity, "tableEntity");
+        Ensure.argIsNotNull(tableClient, "tableEntity");
 
         tableClient.createEntity(tableEntity);
     }
 
     void uploadLocalFileToBlob(File file, String blobName, BlobContainerClient container, boolean shouldCompress)
-            throws IOException {
+            throws IOException, BlobStorageException {
         log.debug("uploadLocalFileToBlob: filePath: {}, blobName: {}, storageUri: {}", file.getPath(), blobName, container.getBlobContainerUrl());
 
         // Ensure
@@ -65,7 +68,7 @@ class AzureStorageClient {
         }
     }
 
-    void compressAndUploadFileToBlob(File sourceFile, BlobClient blob) throws IOException {
+    void compressAndUploadFileToBlob(File sourceFile, BlobClient blob) throws IOException, BlobStorageException {
         Ensure.fileExists(sourceFile, "sourceFile");
         Ensure.argIsNotNull(blob, "blob");
 
@@ -75,7 +78,7 @@ class AzureStorageClient {
         }
     }
 
-    void uploadFileToBlob(File sourceFile, BlobClient blobClient) throws IOException {
+    void uploadFileToBlob(File sourceFile, BlobClient blobClient) throws IOException, BlobStorageException {
         // Ensure
         Ensure.argIsNotNull(blobClient, "blob");
         Ensure.fileExists(sourceFile, "sourceFile");
@@ -84,7 +87,7 @@ class AzureStorageClient {
     }
 
     void uploadStreamToBlob(InputStream inputStream, String blobName, BlobContainerClient container, boolean shouldCompress)
-            throws IOException, URISyntaxException {
+            throws IOException, URISyntaxException, BlobStorageException {
         log.debug("uploadStreamToBlob: blobName: {}, storageUri: {}", blobName, container);
 
         // Ensure
@@ -100,7 +103,7 @@ class AzureStorageClient {
         }
     }
 
-    void uploadStream(InputStream inputStream, BlobClient blob) throws IOException {
+    void uploadStream(InputStream inputStream, BlobClient blob) throws IOException, BlobStorageException {
         // Ensure
         Ensure.argIsNotNull(inputStream, "inputStream");
         Ensure.argIsNotNull(blob, "blob");
@@ -110,7 +113,7 @@ class AzureStorageClient {
         blobOutputStream.close();
     }
 
-    void compressAndUploadStream(InputStream inputStream, BlobClient blob) throws IOException {
+    void compressAndUploadStream(InputStream inputStream, BlobClient blob) throws IOException, BlobStorageException {
         // Ensure
         Ensure.argIsNotNull(inputStream, "inputStream");
         Ensure.argIsNotNull(blob, "blob");

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientImpl.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientImpl.java
@@ -4,8 +4,10 @@
 package com.microsoft.azure.kusto.ingest;
 
 import com.azure.data.tables.models.TableEntity;
+import com.azure.data.tables.models.TableServiceException;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.common.policy.RequestRetryOptions;
+import com.azure.storage.queue.models.QueueStorageException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.microsoft.azure.kusto.data.*;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
@@ -139,7 +141,7 @@ public class QueuedIngestClientImpl extends IngestClientBase implements QueuedIn
             return reportToTable
                     ? new TableReportIngestionResult(tableStatuses)
                     : new IngestionStatusResult(status);
-        } catch (BlobStorageException e) {
+        } catch (BlobStorageException | QueueStorageException | TableServiceException e) {
             throw new IngestionServiceException("Failed to ingest from blob", e);
         } catch (IOException | URISyntaxException e) {
             throw new IngestionClientException("Failed to ingest from blob", e);

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ResourceManager.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ResourceManager.java
@@ -145,7 +145,7 @@ class ResourceManager implements Closeable {
                     refreshIngestionAuthToken();
                     timer.schedule(new RefreshIngestionAuthTokenTask(), defaultRefreshTime);
                 } catch (Exception e) {
-                    log.error("Error in refreshIngestionAuthToken." + e.getMessage(), e);
+                    log.error("Error in refreshIngestionAuthToken. " + e.getMessage(), e);
                     timer.schedule(new RefreshIngestionAuthTokenTask(), refreshTimeOnFailure);
                 }
             }
@@ -271,9 +271,9 @@ class ResourceManager implements Closeable {
                 }
                 log.info("Refreshing Ingestion Resources Finised");
             } catch (DataServiceException e) {
-                throw new IngestionServiceException(e.getIngestionSource(), "Error refreshing IngestionResources" + e.getMessage(), e);
+                throw new IngestionServiceException(e.getIngestionSource(), "Error refreshing IngestionResources. " + e.getMessage(), e);
             } catch (DataClientException e) {
-                throw new IngestionClientException(e.getIngestionSource(), "Error refreshing IngestionResources" + e.getMessage(), e);
+                throw new IngestionClientException(e.getIngestionSource(), "Error refreshing IngestionResources. " + e.getMessage(), e);
             } catch (Throwable e) {
                 throw new IngestionClientException(e.getMessage(), e);
             } finally {
@@ -297,9 +297,9 @@ class ResourceManager implements Closeable {
                     identityToken = resultTable.getString(0);
                 }
             } catch (DataServiceException e) {
-                throw new IngestionServiceException(e.getIngestionSource(), "Error refreshing IngestionAuthToken" + e.getMessage(), e);
+                throw new IngestionServiceException(e.getIngestionSource(), "Error refreshing IngestionAuthToken. " + e.getMessage(), e);
             } catch (DataClientException e) {
-                throw new IngestionClientException(e.getIngestionSource(), "Error refreshing IngestionAuthToken" + e.getMessage(), e);
+                throw new IngestionClientException(e.getIngestionSource(), "Error refreshing IngestionAuthToken. " + e.getMessage(), e);
             } catch (Throwable e) {
                 throw new IngestionClientException(e.getMessage(), e);
             } finally {

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionResult.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionResult.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.azure.kusto.ingest.result;
 
+import com.azure.data.tables.implementation.models.TableServiceErrorException;
+
 import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -12,7 +14,7 @@ public interface IngestionResult extends Serializable {
     /// Retrieves the detailed ingestion status of
     /// all data ingestion operations into Kusto associated with this com.microsoft.azure.kusto.ingest.IKustoIngestionResult instance.
     /// </summary>
-    List<IngestionStatus> getIngestionStatusCollection() throws URISyntaxException;
+    List<IngestionStatus> getIngestionStatusCollection() throws URISyntaxException, TableServiceErrorException;
 
     int getIngestionStatusesLength();
 }

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/TableReportIngestionResult.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/TableReportIngestionResult.java
@@ -4,6 +4,7 @@
 package com.microsoft.azure.kusto.ingest.result;
 
 import com.azure.data.tables.TableClient;
+import com.azure.data.tables.implementation.models.TableServiceErrorException;
 import com.azure.data.tables.models.TableEntity;
 
 import java.util.LinkedList;
@@ -17,7 +18,7 @@ public class TableReportIngestionResult implements IngestionResult {
     }
 
     @Override
-    public List<IngestionStatus> getIngestionStatusCollection() {
+    public List<IngestionStatus> getIngestionStatusCollection() throws TableServiceErrorException {
         List<IngestionStatus> results = new LinkedList<>();
         for (IngestionStatusInTableDescription descriptor : descriptors) {
             TableClient table = descriptor.getTableClient();


### PR DESCRIPTION
new Storage exceptions are hidden as annotations of kind RuntimeException and need to be added manually. 
Example:
@UnexpectedResponseExceptionType(TableServiceErrorException.class)
