### PR TITLE
more dependency bumps! more!

### DIFF
--- a/data/pom.xml
+++ b/data/pom.xml
@@ -220,13 +220,13 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
+            <artifactId>bcprov-jdk18on</artifactId>
             <version>${bouncycastle.version}</version>
             <scope>test</scope>
         </dependency>

--- a/ingest/pom.xml
+++ b/ingest/pom.xml
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.11</version>
+            <version>${commons-codec.version}</version>
         </dependency>
         <dependency>
             <groupId>io.projectreactor</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <slf4j.version>1.8.0-beta4</slf4j.version>
         <commons-lang3.version>3.12.0</commons-lang3.version>
         <commons-text.version>1.10.0</commons-text.version>
+        <commons-codec.version>1.13</commons-codec.version>
         <msal4j.version>1.13.8</msal4j.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
@@ -53,9 +54,9 @@
         <resilience4j.version>1.7.1</resilience4j.version>
         <io.vavr.version>0.10.2</io.vavr.version>
         <!-- Test dependencies -->
-        <bouncycastle.version>1.70</bouncycastle.version>
+        <bouncycastle.version>1.75</bouncycastle.version>
         <jsonassert.version>1.5.0</jsonassert.version>
-        <sqlite-jdbc.version>3.36.0.2</sqlite-jdbc.version>
+        <sqlite-jdbc.version>3.42.0.0</sqlite-jdbc.version>
         <annotations.version>22.0.0</annotations.version>
 
         <!-- Other dependencies -->


### PR DESCRIPTION
changes bouncycastle library versions to jdk18on versions (reason: compatibility/future proofing)
bumps commons-codec and moves version to maven property in parent pom (reason vulnerability and housekeeping)
bumps sqlite-jdbc (reason: vulnerability)

153 tests run, only 1 error, the usual suspect. E2ETest. Error message is "SecretPath is not set" (I assume I can't run this one)