### PR TITLE
bumps dependencies and removes vulnerability caused by apache httpclient

### DIFF
--- a/data/pom.xml
+++ b/data/pom.xml
@@ -169,6 +169,10 @@
                     <artifactId>httpcore</artifactId>
                     <groupId>org.apache.httpcomponents</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>commons-codec</artifactId>
+                    <groupId>org.apache.commons</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -201,6 +205,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
             <version>${commons-text.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>${commons-codec.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,40 +36,40 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <!-- Use 1.0.6 for fasterxml v 2.12.x (good for databricks runtime 2.10.x) -->
-        <azure-bom-version>1.2.15</azure-bom-version>
+        <azure-bom-version>1.2.18</azure-bom-version>
 
         <!-- Versions below are for several dependencies we're using in the data & ingest modules -->
         <!-- Ideally, versions below should align with latest databricks runtime dependency versions -->
         <!-- Compile dependencies -->
-        <slf4j.version>1.8.0-beta4</slf4j.version>
-        <commons-lang3.version>3.12.0</commons-lang3.version>
-        <commons-text.version>1.10.0</commons-text.version>
-        <commons-codec.version>1.13</commons-codec.version>
-        <msal4j.version>1.13.8</msal4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <commons-lang3.version>3.14.0</commons-lang3.version>
+        <commons-text.version>1.11.0</commons-text.version>
+        <commons-codec.version>1.16.0</commons-codec.version>
+        <msal4j.version>1.13.10</msal4j.version>
         <httpclient.version>4.5.14</httpclient.version>
         <httpcore.version>4.4.16</httpcore.version>
-        <fasterxml.jackson.core.version>2.14.2</fasterxml.jackson.core.version>
-        <reactor-core.version>3.4.19</reactor-core.version>
+        <fasterxml.jackson.core.version>2.15.2</fasterxml.jackson.core.version>
+        <reactor-core.version>3.4.34</reactor-core.version>
         <univocity-parsers.version>2.9.1</univocity-parsers.version>
         <resilience4j.version>1.7.1</resilience4j.version>
         <io.vavr.version>0.10.2</io.vavr.version>
         <!-- Test dependencies -->
-        <bouncycastle.version>1.75</bouncycastle.version>
+        <bouncycastle.version>1.77</bouncycastle.version>
         <jsonassert.version>1.5.0</jsonassert.version>
-        <sqlite-jdbc.version>3.42.0.0</sqlite-jdbc.version>
+        <sqlite-jdbc.version>3.44.1.0</sqlite-jdbc.version>
         <annotations.version>22.0.0</annotations.version>
 
         <!-- Other dependencies -->
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.2.1</maven-surefire-plugin.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>
         <flatten-maven-plugin.version>1.2.5</flatten-maven-plugin.version>
         <junit.version>5.8.2</junit.version>
         <mockito.version>5.7.0</mockito.version>
-        <jacoco.version>0.8.7</jacoco.version>
+        <jacoco.version>0.8.11</jacoco.version>
     </properties>
     <profiles>
         <profile>


### PR DESCRIPTION
Excluded vulnerable commons-codec version from old Apache client and overrode with new version
Moved Jackson to 2.15.2, current version supported by Databricks 14.2 GA
Moved slf4j back to 1.7.36 (newer and better maintained than 1.8 series)
Bump other dependencies within minor version release train