### PR TITLE
Fix exception java.lang.NoClassDefFoundError: io.opentelemetry.sdk.logs.SdkLogEmitterProviderBuilder

### DIFF
--- a/data/pom.xml
+++ b/data/pom.xml
@@ -207,11 +207,6 @@
             <version>${commons-text.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>${commons-codec.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -108,7 +108,7 @@
             <dependency>
                 <groupId>io.opentelemetry</groupId>
                 <artifactId>opentelemetry-bom</artifactId>
-                <version>1.20.1</version>
+                <version>1.31.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -139,9 +139,8 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-core-tracing-opentelemetry</artifactId>
-            <version>1.0.0-beta.30</version>
+            <version>1.0.0-beta.42</version>
         </dependency>
-
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
@@ -157,7 +156,7 @@
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-semconv</artifactId>
-            <version>1.20.1-alpha</version>
+            <version>1.30.1-alpha</version>
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>


### PR DESCRIPTION
### Added
### Changed
### Fixed
Fix exception java.lang.NoClassDefFoundError: io.opentelemetry.sdk.logs.SdkLogEmitterProviderBuilder in StarterApp