### PR TITLE
Fix CRP's servertimeout bugs in how it's set/get, and make consistent

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientRequestProperties.java
@@ -227,7 +227,7 @@ public class ClientRequestProperties implements Serializable, TraceableAttribute
         ObjectNode optionsAsJSON = Utils.getObjectMapper().valueToTree(this.options);
         Object timeoutObj = getOption(OPTION_SERVER_TIMEOUT);
         if (timeoutObj != null) {
-            optionsAsJSON.put(OPTION_SERVER_TIMEOUT, getTimeoutAsTimespan(timeoutObj));
+            optionsAsJSON.put(OPTION_SERVER_TIMEOUT, getTimeoutAsCslTimespan(timeoutObj));
         }
 
         ObjectNode json = Utils.getObjectMapper().createObjectNode();
@@ -327,11 +327,11 @@ public class ClientRequestProperties implements Serializable, TraceableAttribute
      * Gets the amount of time a query may execute on the service before it times out, formatted as a KQL timespan.
      * @param timeoutObj amount of time before timeout, which may be a Long, String or Integer.
      *                    Value must be between 1 minute and 1 hour, and so value below the minimum or above the maximum will be adjusted accordingly.
-     * @Deprecated use {@link #getTimeoutAsTimespan(Object)} instead.
+     * @Deprecated use {@link #getTimeoutAsCslTimespan(Object)} instead.
      */
     @Deprecated
     String getTimeoutAsString(Object timeoutObj) {
-        return getTimeoutAsTimespan(timeoutObj);
+        return getTimeoutAsCslTimespan(timeoutObj);
     }
 
     /**
@@ -339,7 +339,7 @@ public class ClientRequestProperties implements Serializable, TraceableAttribute
      * @param timeoutObj amount of time before timeout, which may be a Long, String or Integer.
      *                    Value must be between 1 minute and 1 hour, and so value below the minimum or above the maximum will be adjusted accordingly.
      */
-    String getTimeoutAsTimespan(Object timeoutObj) {
+    String getTimeoutAsCslTimespan(Object timeoutObj) {
         Long timeoutInMilliSec = getTimeoutInMilliSec(timeoutObj);
 
         if (timeoutInMilliSec == null) {
@@ -354,7 +354,7 @@ public class ClientRequestProperties implements Serializable, TraceableAttribute
      * Gets the amount of time a query may execute on the service before it times out, formatted as a KQL timespan.
      * Value must be between 1 minute and 1 hour, and so if the value had been set below the minimum or above the maximum, the value returned will be adjusted accordingly.
      */
-    String getTimeoutAsTimespan() {
-        return getTimeoutAsTimespan(getOption(OPTION_SERVER_TIMEOUT));
+    String getTimeoutAsCslTimespan() {
+        return getTimeoutAsCslTimespan(getOption(OPTION_SERVER_TIMEOUT));
     }
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Utils.java
@@ -67,21 +67,27 @@ public class Utils {
     }
 
     public static String formatDurationAsTimespan(Duration duration) {
-        long seconds = duration.getSeconds();
+        long durationInSeconds = duration.getSeconds();
         int nanos = duration.getNano();
-        long hours = TimeUnit.SECONDS.toHours(seconds) % TimeUnit.DAYS.toHours(1);
-        long minutes = TimeUnit.SECONDS.toMinutes(seconds) % TimeUnit.MINUTES.toSeconds(1);
-        long secs = seconds % TimeUnit.MINUTES.toSeconds(1);
-        long days = TimeUnit.SECONDS.toDays(seconds);
-        String positive = String.format(
-                "%02d.%02d:%02d:%02d.%.3s",
-                days,
+        long hours = TimeUnit.SECONDS.toHours(durationInSeconds) % TimeUnit.DAYS.toHours(1);
+        long minutes = TimeUnit.SECONDS.toMinutes(durationInSeconds) % TimeUnit.HOURS.toMinutes(1);
+        long seconds = durationInSeconds % TimeUnit.MINUTES.toSeconds(1);
+        long days = TimeUnit.SECONDS.toDays(durationInSeconds);
+
+        String absoluteVal = "";
+        if (days != 0) {
+            absoluteVal += String.format("%02d.", days);
+        }
+        absoluteVal += String.format(
+                "%02d:%02d:%02d",
                 hours,
                 minutes,
-                secs,
-                nanos);
+                seconds);
+        if (nanos != 0) {
+            absoluteVal += String.format(".%.3s", nanos);
+        }
 
-        return seconds < 0 ? "-" + positive : positive;
+        return durationInSeconds < 0 ? "-" + absoluteVal : absoluteVal;
     }
 
     public static boolean isRetriableIOException(IOException ex) {

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -11,7 +11,9 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -19,43 +21,78 @@ import java.time.ZoneId;
 import java.util.Date;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import static com.microsoft.azure.kusto.data.ClientRequestProperties.OPTION_SERVER_TIMEOUT;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ClientRequestPropertiesTest {
-    @Test
-    @DisplayName("test set/get timeout")
-    void timeoutSetGet() {
-        ClientRequestProperties props = new ClientRequestProperties();
-        Long expected = TimeUnit.MINUTES.toMillis(10);
-
-        // before setting value should be null
-        Assertions.assertNull(props.getTimeoutInMilliSec());
-
-        props.setTimeoutInMilliSec(expected);
-        Assertions.assertEquals(expected, props.getTimeoutInMilliSec());
-
-        Object timeoutObj = props.getOption(OPTION_SERVER_TIMEOUT);
-        Assertions.assertEquals("00.00:10:00.0", props.getTimeoutAsString(timeoutObj));
+    // Used by the 3 parameterized tests below, in the format: {inputTimespan, inputMillis, expectedTimespan, expectedMillis}. Each method uses only one of the
+    // 2 input parameters.
+    private static Stream<Arguments> provideInputsForConvertTimeoutBetweenMillisAndTimespan() {
+        return Stream.of(
+                Arguments.of("00:40:02", TimeUnit.MINUTES.toMillis(40) + TimeUnit.SECONDS.toMillis(2), "00:40:02",
+                        TimeUnit.MINUTES.toMillis(40) + TimeUnit.SECONDS.toMillis(2)),
+                // If set to over MAX_TIMEOUT_MS - value should be MAX_TIMEOUT_MS
+                Arguments.of("01:40:02.1", TimeUnit.HOURS.toMillis(1) + TimeUnit.MINUTES.toMillis(40) + TimeUnit.SECONDS.toMillis(2) + 100, "01:00:00",
+                        ClientRequestProperties.MAX_TIMEOUT_MS),
+                Arguments.of("1.01:40:02.1",
+                        TimeUnit.DAYS.toMillis(1) + TimeUnit.HOURS.toMillis(1) + TimeUnit.MINUTES.toMillis(40) + TimeUnit.SECONDS.toMillis(2) + 100, "01:00:00",
+                        ClientRequestProperties.MAX_TIMEOUT_MS),
+                // If set to under MIN_TIMEOUT_MS - value should be MIN_TIMEOUT_MS
+                Arguments.of("00:00:12.6", TimeUnit.SECONDS.toMillis(12) + 600, "00:01:00", ClientRequestProperties.MIN_TIMEOUT_MS),
+                Arguments.of("00:00:00", 0L, "00:01:00", ClientRequestProperties.MIN_TIMEOUT_MS),
+                Arguments.of(null, null, null, null));
     }
 
-    @Test
-    @DisplayName("test set/get timeout with value that's below the minimum")
-    void timeoutSetGetInvalidValue() {
-        ClientRequestProperties props = new ClientRequestProperties();
-        Long expected = TimeUnit.SECONDS.toMillis(10);
+    @ParameterizedTest
+    @MethodSource("provideInputsForConvertTimeoutBetweenMillisAndTimespan")
+    @DisplayName("Set the timeout in milliseconds, using helper method")
+    void setTimeoutInMilliSec(String serverTimeoutOptionTimespan, Long serverTimeoutOptionMillis, String expectedTimespan, Long expectedMillis) {
+        ClientRequestProperties clientRequestProperties = new ClientRequestProperties();
 
         // before setting value should be null
-        Assertions.assertNull(props.getTimeoutInMilliSec());
+        Assertions.assertNull(clientRequestProperties.getTimeoutInMilliSec());
+        Object timeoutObj = clientRequestProperties.getOption(OPTION_SERVER_TIMEOUT);
+        Assertions.assertNull(clientRequestProperties.getTimeoutAsString(timeoutObj));
 
-        IllegalArgumentException thrownException = assertThrows(IllegalArgumentException.class,
-                () -> props.setTimeoutInMilliSec(expected));
+        clientRequestProperties.setTimeoutInMilliSec(serverTimeoutOptionMillis);
+        Assertions.assertEquals(clientRequestProperties.getTimeoutInMilliSec(), expectedMillis);
+        Assertions.assertEquals(clientRequestProperties.getOption(OPTION_SERVER_TIMEOUT), expectedMillis);
+        Assertions.assertEquals(clientRequestProperties.getTimeoutAsTimespan(), expectedTimespan);
+    }
 
-        Assertions.assertNull(props.getTimeoutInMilliSec());
+    @ParameterizedTest
+    @MethodSource("provideInputsForConvertTimeoutBetweenMillisAndTimespan")
+    @DisplayName("Set the timeout in milliseconds, directly via OPTION_SERVER_TIMEOUT")
+    void setOPTION_SERVER_TIMEOUTProvidingMillis(String serverTimeoutOptionTimespan, Long serverTimeoutOptionMillis, String expectedTimespan,
+            Long expectedMillis) {
+        ClientRequestProperties clientRequestProperties = new ClientRequestProperties();
 
-        Object timeoutObj = props.getOption(OPTION_SERVER_TIMEOUT);
-        Assertions.assertEquals("", props.getTimeoutAsString(timeoutObj));
+        // before setting value should be null
+        Assertions.assertNull(clientRequestProperties.getTimeoutInMilliSec());
+        Object timeoutObj = clientRequestProperties.getOption(OPTION_SERVER_TIMEOUT);
+        Assertions.assertNull(clientRequestProperties.getTimeoutAsString(timeoutObj));
+
+        clientRequestProperties.setOption(ClientRequestProperties.OPTION_SERVER_TIMEOUT, serverTimeoutOptionMillis);
+        Assertions.assertEquals(clientRequestProperties.getTimeoutInMilliSec(), expectedMillis);
+        Assertions.assertEquals(clientRequestProperties.getTimeoutAsTimespan(), expectedTimespan);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInputsForConvertTimeoutBetweenMillisAndTimespan")
+    @DisplayName("Set the timeout to a timespan, directly via OPTION_SERVER_TIMEOUT")
+    void setOPTION_SERVER_TIMEOUTProvidingTimespan(String serverTimeoutOptionTimespan, Long serverTimeoutOptionMillis, String expectedTimespan,
+            Long expectedMillis) {
+        ClientRequestProperties clientRequestProperties = new ClientRequestProperties();
+
+        // before setting value should be null
+        Assertions.assertNull(clientRequestProperties.getTimeoutInMilliSec());
+        Object timeoutObj = clientRequestProperties.getOption(OPTION_SERVER_TIMEOUT);
+        Assertions.assertNull(clientRequestProperties.getTimeoutAsString(timeoutObj));
+
+        clientRequestProperties.setOption(ClientRequestProperties.OPTION_SERVER_TIMEOUT, serverTimeoutOptionTimespan);
+        Assertions.assertEquals(clientRequestProperties.getTimeoutInMilliSec(), expectedMillis);
+        Assertions.assertEquals(clientRequestProperties.getTimeoutAsTimespan(), expectedTimespan);
     }
 
     @Test
@@ -72,21 +109,21 @@ class ClientRequestPropertiesTest {
     @Test
     @DisplayName("test ClientRequestProperties fromString")
     void stringToProperties() throws JsonProcessingException {
-        String properties = "{\"Options\":{\"servertimeout\":\"01:25:11.111\", \"Content-Encoding\":\"gzip\"},\"Parameters\":{\"birthday\":\"datetime(1970-05-11)\",\"courses\":\"dynamic(['Java', 'C++'])\"}}";
+        String properties = "{\"Options\":{\"servertimeout\":\"00:25:11.111\", \"Content-Encoding\":\"gzip\"},\"Parameters\":{\"birthday\":\"datetime(1970-05-11)\",\"courses\":\"dynamic(['Java', 'C++'])\"}}";
         ClientRequestProperties crp = ClientRequestProperties.fromString(properties);
 
-        assert crp != null;
-        assert crp.toJson().get("Options").get("servertimeout").asText().equals("01:25:11.111");
-        assert crp.getTimeoutInMilliSec() != null;
-        assert crp.getOption("Content-Encoding").equals("gzip");
-        assert crp.getParameter("birthday").equals("datetime(1970-05-11)");
-        assert crp.getParameter("courses").equals("dynamic(['Java', 'C++'])");
+        Assertions.assertNotNull(crp);
+        Assertions.assertEquals("00:25:11.111", crp.toJson().get("Options").get(OPTION_SERVER_TIMEOUT).asText());
+        Assertions.assertNotNull(crp.getTimeoutInMilliSec());
+        Assertions.assertEquals("gzip", crp.getOption("Content-Encoding"));
+        Assertions.assertEquals("datetime(1970-05-11)", crp.getParameter("birthday"));
+        Assertions.assertEquals("dynamic(['Java', 'C++'])", crp.getParameter("courses"));
 
         Long timeoutMilli = 200000L;
         crp = new ClientRequestProperties();
         crp.setTimeoutInMilliSec(timeoutMilli);
         crp = ClientRequestProperties.fromString(crp.toString());
-        assert crp.getTimeoutInMilliSec().equals(timeoutMilli);
+        Assertions.assertEquals(timeoutMilli, crp.getTimeoutInMilliSec());
     }
 
     @Test

--- a/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/ClientRequestPropertiesTest.java
@@ -58,7 +58,7 @@ class ClientRequestPropertiesTest {
         clientRequestProperties.setTimeoutInMilliSec(serverTimeoutOptionMillis);
         Assertions.assertEquals(clientRequestProperties.getTimeoutInMilliSec(), expectedMillis);
         Assertions.assertEquals(clientRequestProperties.getOption(OPTION_SERVER_TIMEOUT), expectedMillis);
-        Assertions.assertEquals(clientRequestProperties.getTimeoutAsTimespan(), expectedTimespan);
+        Assertions.assertEquals(clientRequestProperties.getTimeoutAsCslTimespan(), expectedTimespan);
     }
 
     @ParameterizedTest
@@ -75,7 +75,7 @@ class ClientRequestPropertiesTest {
 
         clientRequestProperties.setOption(ClientRequestProperties.OPTION_SERVER_TIMEOUT, serverTimeoutOptionMillis);
         Assertions.assertEquals(clientRequestProperties.getTimeoutInMilliSec(), expectedMillis);
-        Assertions.assertEquals(clientRequestProperties.getTimeoutAsTimespan(), expectedTimespan);
+        Assertions.assertEquals(clientRequestProperties.getTimeoutAsCslTimespan(), expectedTimespan);
     }
 
     @ParameterizedTest
@@ -92,7 +92,7 @@ class ClientRequestPropertiesTest {
 
         clientRequestProperties.setOption(ClientRequestProperties.OPTION_SERVER_TIMEOUT, serverTimeoutOptionTimespan);
         Assertions.assertEquals(clientRequestProperties.getTimeoutInMilliSec(), expectedMillis);
-        Assertions.assertEquals(clientRequestProperties.getTimeoutAsTimespan(), expectedTimespan);
+        Assertions.assertEquals(clientRequestProperties.getTimeoutAsCslTimespan(), expectedTimespan);
     }
 
     @Test

--- a/data/src/test/java/com/microsoft/azure/kusto/data/UtilitiesTest.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/UtilitiesTest.java
@@ -2,12 +2,11 @@ package com.microsoft.azure.kusto.data;
 
 import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
 import com.microsoft.azure.kusto.data.exceptions.DataWebException;
-
 import com.microsoft.azure.kusto.data.http.HttpPostUtils;
+import org.apache.http.HttpStatus;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
-import org.apache.http.HttpStatus;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -18,34 +17,8 @@ import java.net.ConnectException;
 import java.net.UnknownHostException;
 import java.nio.file.Paths;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 
 class UtilitiesTest {
-    @Test
-    @DisplayName("Convert millis to .Net timespan")
-    void convertMillisToTimespan() {
-        Long timeout = TimeUnit.MINUTES.toMillis(40) + TimeUnit.SECONDS.toMillis(2); // 40 minutes 2 seconds
-        ClientRequestProperties clientRequestProperties = new ClientRequestProperties();
-        clientRequestProperties.setTimeoutInMilliSec(timeout);
-        Assertions.assertEquals(timeout, clientRequestProperties.getTimeoutInMilliSec());
-        Assertions.assertEquals(timeout, clientRequestProperties.getOption(ClientRequestProperties.OPTION_SERVER_TIMEOUT));
-
-        String serverTimeoutOptionStr = "01:40:02.1";
-        long serverTimeoutOptionMillis = TimeUnit.HOURS.toMillis(1)
-                + TimeUnit.MINUTES.toMillis(40)
-                + TimeUnit.SECONDS.toMillis(2) + 100L;
-        clientRequestProperties.setOption(ClientRequestProperties.OPTION_SERVER_TIMEOUT, serverTimeoutOptionStr);
-        Assertions.assertEquals(serverTimeoutOptionMillis, clientRequestProperties.getTimeoutInMilliSec());
-
-        // If set to over MAX_TIMEOUT_MS - value should be MAX_TIMEOUT_MS
-        clientRequestProperties.setOption(ClientRequestProperties.OPTION_SERVER_TIMEOUT, "1.01:40:02.1");
-        Assertions.assertEquals(ClientRequestProperties.MAX_TIMEOUT_MS,
-                clientRequestProperties.getTimeoutInMilliSec());
-
-        clientRequestProperties.setOption(ClientRequestProperties.OPTION_SERVER_TIMEOUT, "15:00");
-        Assertions.assertEquals(TimeUnit.HOURS.toMillis(15), clientRequestProperties.getTimeoutInMilliSec());
-    }
-
     @Test
     @DisplayName("Test exception creation when the web response is null")
     void createExceptionFromResponseNoResponse() {


### PR DESCRIPTION
### Fixed
Fix CRP's `servertimeout` bugs in how it's set/get, and make consistent

We have 3 different ways to set the `servertimeout`:
1) Set the timeout in milliseconds, using helper method (`clientRequestProperties.setTimeoutInMilliSec(serverTimeoutOptionMillis)`)
2) Set the timeout in milliseconds, directly via OPTION_SERVER_TIMEOUT (`clientRequestProperties.setOption(ClientRequestProperties.OPTION_SERVER_TIMEOUT, serverTimeoutOptionMillis)`)
3) Set the timeout to a timespan, directly via OPTION_SERVER_TIMEOUT (`clientRequestProperties.setOption(ClientRequestProperties.OPTION_SERVER_TIMEOUT, serverTimeoutOptionTimespan)`)

There were inconsistencies between how these 3 worked.

And 3 different ways to get the `servertimeout`:
1) `clientRequestProperties.getTimeoutInMilliSec()`
2) `clientRequestProperties.getOption(OPTION_SERVER_TIMEOUT)`
3) `clientRequestProperties.getTimeoutAsString()` (which really should be `clientRequestProperties.getTimeoutAsTimespan()`)

There were inconsistencies between how these 3 worked.

The easiest way to understand this PR is to look at the requirements (mapping of inputs to expected outputs), defined in `ClientRequestPropertiesTest.provideInputsForConvertTimeoutBetweenMillisAndTimespan()`.