### PR TITLE
Introduces KustoQuery wrapper object

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/Client.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/Client.java
@@ -9,6 +9,9 @@ import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
 import java.io.Closeable;
 
 public interface Client extends Closeable {
+
+    KustoOperationResult execute(KustoQuery kq) throws DataServiceException, DataClientException;
+
     KustoOperationResult execute(String command) throws DataServiceException, DataClientException;
 
     KustoOperationResult execute(String database, String command) throws DataServiceException, DataClientException;
@@ -26,6 +29,8 @@ public interface Client extends Closeable {
     KustoOperationResult executeMgmt(String database, String command) throws DataServiceException, DataClientException;
 
     KustoOperationResult executeMgmt(String database, String command, ClientRequestProperties properties) throws DataServiceException, DataClientException;
+
+    String executeToJsonResult(KustoQuery kq) throws DataServiceException, DataClientException;
 
     String executeToJsonResult(String database) throws DataServiceException, DataClientException;
 

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ClientImpl.java
@@ -84,6 +84,17 @@ class ClientImpl extends BaseClient {
     }
 
     @Override
+    public KustoOperationResult execute(KustoQuery kq) throws DataServiceException, DataClientException {
+        if (kq == null) {
+            throw new IllegalArgumentException("KustoQuery object cannot be null in order to be executed.");
+        }
+        if (kq.getDatabase() == null) {
+            kq.setDatabase(DEFAULT_DATABASE_NAME);
+        }
+        return execute(kq.getDatabase(), kq.getCommand(), kq.getProperties(), determineCommandType(kq.getCommand()));
+    }
+
+    @Override
     public KustoOperationResult execute(String command) throws DataServiceException, DataClientException {
         return execute(DEFAULT_DATABASE_NAME, command);
     }
@@ -162,6 +173,17 @@ class ClientImpl extends BaseClient {
         } catch (Exception e) {
             throw new DataClientException(clusterEndpoint, e.getMessage(), e);
         }
+    }
+
+    @Override
+    public String executeToJsonResult(KustoQuery kq) throws DataServiceException, DataClientException {
+        if (kq == null) {
+            throw new IllegalArgumentException("KustoQuery object cannot be null in order to be executed.");
+        }
+        if (kq.getDatabase() == null) {
+            kq.setDatabase(DEFAULT_DATABASE_NAME);
+        }
+        return executeToJsonResult(kq.getDatabase(), kq.getCommand(), kq.getProperties());
     }
 
     @Override

--- a/data/src/main/java/com/microsoft/azure/kusto/data/KustoQuery.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/KustoQuery.java
@@ -1,0 +1,97 @@
+package com.microsoft.azure.kusto.data;
+
+/** An extensible wrapper class representing a Kusto Query or Command. */
+public class KustoQuery {
+
+    private String command;
+    private String database;
+    private ClientRequestProperties properties;
+
+    /**
+     * A constructor providing only the command to be executed.
+     * @param command the command to be executed
+     */
+    public KustoQuery(String command) {
+        this.command = command;
+    }
+
+    /**
+     * A constructor providing the command to be executed and the database to target.
+     * @param command the command to be executed
+     * @param database the name of the database to target
+     */
+    public KustoQuery(String command, String database) {
+        this.command = command;
+        this.database = database;
+    }
+
+    /**
+     * A constructor providing the command to be executed and sanitized query parameters.
+     * @param command the command to be executed
+     * @param properties a map of query parameters and other request properties
+     */
+    public KustoQuery(String command, ClientRequestProperties properties) {
+        this.command = command;
+        this.properties = properties;
+    }
+
+    /**
+     * A constructor providing the command to be executed, sanitized query parameters, and the database to target.
+     * @param command the command to be executed
+     * @param database the name of the database to target
+     * @param properties a map of query parameters and other request properties
+     */
+    public KustoQuery(String command, String database, ClientRequestProperties properties) {
+        this.command = command;
+        this.database = database;
+        this.properties = properties;
+    }
+
+    /**
+     * A getter for this KustoQuery object's inner command String.
+     * @return the command
+     */
+    public String getCommand() {
+        return command;
+    }
+
+    /**
+     * A setter for this KustoQuery object's inner command String.
+     * @param command the command
+     */
+    public void setCommand(String command) {
+        this.command = command;
+    }
+
+    /**
+     * A getter for this KustoQuery object's inner database String.
+     * @return the database name
+     */
+    public String getDatabase() {
+        return database;
+    }
+
+    /**
+     * A setter for this KustoQuery object's inner database String.
+     * @param database the database name
+     */
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    /**
+     * A getter for this KustoQuery object's inner ClientRequestProperties.
+     * @return the properties
+     */
+    public ClientRequestProperties getProperties() {
+        return properties;
+    }
+
+    /**
+     * A setter for this KustoQuery object's inner ClientRequestProperties.
+     * @param properties the properties
+     */
+    public void setProperties(ClientRequestProperties properties) {
+        this.properties = properties;
+    }
+}


### PR DESCRIPTION
### Added
- KustoQuery object

**Why:**
Adding this object allows for extensibility without changing method signatures or chaining methods until you reach an implementation, which should reduce the surface of the library and make the code easier to read. Currently to execute a command you must pass each property needed individually. Sometimes this results in a lot of method chaining, which can get pretty verbose and hard to track. Additionally, when new options are made available to the user, more chains are needed to account for this, which means a lot more verbosity.

**Request:**
Deprecate the old methods that take each parameter individually, including the command and management methods, in favor of a single execute method that takes a KustoQuery object. This is a big change for users, however it should be a relatively simple one, and if the methods are annotated as being deprecated for a time prior to removal, this will give users time to migrate to using the KustoQuery object.

New usage:

```java
   var client = ClientFactory.createClient(engine_connection_string, httpClientProperties);

   // Example 1:
   client.execute(new KustoQuery("my query"));
   
   // Example 2
   var myProperties = new ClientRequestProperties();
   var query = new KustoQuery("my query", myProperties);
   client.executeToJsonResult(query);
```
