### PR TITLE
fixes token fetch when account provided and bumps version

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/MsalTokenProviderBase.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/MsalTokenProviderBase.java
@@ -93,7 +93,7 @@ public abstract class MsalTokenProviderBase extends CloudDependentTokenProviderB
                 authorityUrl = firstPartyAuthorityUrl;
             }
 
-            return SilentParameters.builder(scopes).account(account).authorityUrl(authorityUrl).build();
+            return SilentParameters.builder(scopes, account).authorityUrl(authorityUrl).build();
         }
         return SilentParameters.builder(scopes).authorityUrl(aadAuthorityUrl).build();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </developers>
 
     <properties>
-        <revision>5.1.1</revision> <!-- CHANGE THIS to adjust project version-->
+        <revision>5.1.2</revision> <!-- CHANGE THIS to adjust project version-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <azure-bom-version>1.2.24</azure-bom-version>


### PR DESCRIPTION
### Fixed

MsalTokenProviders fail when getting silent parameters due to changes to a deprecated method in msal4j.

This PR replaces a usage of that deprecated method.