### PR TITLE
Add support for configuring SSL/TLS protocols in HttpClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Introduce a new `supportedProtocols` field in `HttpClientProperties` to allow specifying SSL/TLS protocols.
+
 ## [5.1.1] - 2024-07-25
 ### Fixed
 - Fix population of application and client version for tracing

--- a/data/src/main/java/com/microsoft/azure/kusto/data/HttpClientProperties.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/HttpClientProperties.java
@@ -13,6 +13,7 @@ public class HttpClientProperties {
     private final Integer maxConnectionTotal;
     private final Integer maxConnectionRoute;
     private final HttpHost proxy;
+    private final String[] supportedProtocols;
 
     private HttpClientProperties(HttpClientPropertiesBuilder builder) {
         this.maxIdleTime = builder.maxIdleTime;
@@ -21,6 +22,7 @@ public class HttpClientProperties {
         this.maxConnectionTotal = builder.maxConnectionsTotal;
         this.maxConnectionRoute = builder.maxConnectionsPerRoute;
         this.proxy = builder.proxy;
+        this.supportedProtocols = builder.supportedProtocols;
     }
 
     /**
@@ -98,6 +100,10 @@ public class HttpClientProperties {
         return proxy;
     }
 
+    public String[] supportedProtocols() {
+        return supportedProtocols;
+    }
+
     public static class HttpClientPropertiesBuilder {
 
         private Integer maxIdleTime = 120;
@@ -106,6 +112,7 @@ public class HttpClientProperties {
         private Integer maxConnectionsTotal = 40;
         private Integer maxConnectionsPerRoute = 40;
         private HttpHost proxy = null;
+        private String[] supportedProtocols = null;
 
         private HttpClientPropertiesBuilder() {
         }
@@ -190,9 +197,21 @@ public class HttpClientProperties {
             return this;
         }
 
+
+        /**
+         * Sets the list of supported SSL/TLS protocols.
+         * @param tlsProtocols the list of supported protocols
+         * @return the builder instance
+         */
+        public HttpClientPropertiesBuilder supportedProtocols(String[] tlsProtocols) {
+            this.supportedProtocols = tlsProtocols;
+            return this;
+        }
+
         public HttpClientProperties build() {
             return new HttpClientProperties(this);
         }
+
     }
 
 }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/http/HttpClientFactory.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/http/HttpClientFactory.java
@@ -5,6 +5,7 @@ import org.apache.http.HeaderElement;
 import org.apache.http.HeaderElementIterator;
 import org.apache.http.HttpResponse;
 import org.apache.http.conn.ConnectionKeepAliveStrategy;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.message.BasicHeaderElementIterator;
@@ -13,6 +14,8 @@ import org.apache.http.protocol.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SSLContext;
+import java.security.NoSuchAlgorithmException;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
@@ -48,6 +51,15 @@ public class HttpClientFactory {
 
         if (properties.getProxy() != null) {
             httpClientBuilder.setProxy(properties.getProxy());
+        }
+
+        if (properties.supportedProtocols() != null) {
+
+            try {
+                httpClientBuilder.setSSLSocketFactory(new SSLConnectionSocketFactory(SSLContext.getDefault(), properties.supportedProtocols(), null, SSLConnectionSocketFactory.getDefaultHostnameVerifier()));
+            } catch (NoSuchAlgorithmException e) {
+                LOGGER.error("Failed to set supported protocols", e);
+            }
         }
 
         return httpClientBuilder.build();


### PR DESCRIPTION
Introduce a new `supportedProtocols` field in `HttpClientProperties` to allow specifying SSL/TLS protocols.
