### PR TITLE
Remove unused timeout from HttpClientProperties and ResourceManager

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/http/HttpClientProperties.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/http/HttpClientProperties.java
@@ -105,7 +105,6 @@ public class HttpClientProperties {
         private boolean keepAlive;
         private Integer maxKeepAliveTime = 120;
         private Integer maxConnectionsTotal = 40;
-        private Duration timeout = Duration.ofMinutes(10);
         private Class<? extends HttpClientProvider> provider = null;
         private ProxyOptions proxy = null;
 
@@ -181,17 +180,6 @@ public class HttpClientProperties {
         }
 
         /**
-         * Sets a response timeout to use by default on the client's requests.
-         *
-         * @param timeout the requested response timeout
-         * @return the builder instance
-         */
-        public HttpClientPropertiesBuilder timeout(Duration timeout) {
-            this.timeout = timeout;
-            return this;
-        }
-
-        /**
          * Sets a proxy server to use for the client.
          *
          * @param proxy the proxy server
@@ -206,5 +194,4 @@ public class HttpClientProperties {
             return new HttpClientProperties(this);
         }
     }
-
 }

--- a/data/src/test/resources/simplelogger.properties
+++ b/data/src/test/resources/simplelogger.properties
@@ -5,3 +5,5 @@
 # Must be one of ("trace", "debug", "info", "warn", or "error").
 # If not specified, defaults to "info".
 org.slf4j.simpleLogger.log.com.microsoft.azure.kusto=debug
+#org.slf4j.simpleLogger.showDateTime=true
+#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ResourceManager.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ResourceManager.java
@@ -51,7 +51,6 @@ class ResourceManager implements Closeable, IngestionResourceManager {
     private static final long REFRESH_INGESTION_RESOURCES_PERIOD = TimeUnit.HOURS.toMillis(1);
     private static final long REFRESH_INGESTION_RESOURCES_PERIOD_ON_FAILURE = TimeUnit.MINUTES.toMillis(1);
     private static final long REFRESH_RESULT_POLL_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(15);
-    public static final Duration UPLOAD_TIMEOUT = Duration.ofMinutes(10);
     private final Client client;
     private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Timer refreshTasksTimer;
@@ -74,7 +73,7 @@ class ResourceManager implements Closeable, IngestionResourceManager {
         this.client = client;
         // Using ctor with client so that the dependency is used
         this.httpClient = httpClient == null
-                ? HttpClientFactory.create(HttpClientProperties.builder().timeout(UPLOAD_TIMEOUT).build())
+                ? HttpClientFactory.create(HttpClientProperties.builder().build())
                 : httpClient;
 
         // Refresh tasks

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ResourceManager.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ResourceManager.java
@@ -51,7 +51,7 @@ class ResourceManager implements Closeable, IngestionResourceManager {
     private static final long REFRESH_INGESTION_RESOURCES_PERIOD = TimeUnit.HOURS.toMillis(1);
     private static final long REFRESH_INGESTION_RESOURCES_PERIOD_ON_FAILURE = TimeUnit.MINUTES.toMillis(1);
     private static final long REFRESH_RESULT_POLL_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(15);
-    public static final int UPLOAD_TIMEOUT_MINUTES = 10;
+    public static final Duration UPLOAD_TIMEOUT = Duration.ofMinutes(10);
     private final Client client;
     private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
     private Timer refreshTasksTimer;
@@ -74,7 +74,7 @@ class ResourceManager implements Closeable, IngestionResourceManager {
         this.client = client;
         // Using ctor with client so that the dependency is used
         this.httpClient = httpClient == null
-                ? HttpClientFactory.create(HttpClientProperties.builder().timeout(Duration.ofMinutes(UPLOAD_TIMEOUT_MINUTES)).build())
+                ? HttpClientFactory.create(HttpClientProperties.builder().timeout(UPLOAD_TIMEOUT).build())
                 : httpClient;
 
         // Refresh tasks

--- a/ingest/src/test/resources/simplelogger.properties
+++ b/ingest/src/test/resources/simplelogger.properties
@@ -5,3 +5,5 @@
 # Must be one of ("trace", "debug", "info", "warn", or "error").
 # If not specified, defaults to "info".
 org.slf4j.simpleLogger.log.com.microsoft.azure.kusto=debug
+#org.slf4j.simpleLogger.showDateTime=true
+#org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z


### PR DESCRIPTION
Returning old computer as I'm upgrading to a new computer, and found these minor improvements lying around locally.