### PR TITLE
Auth metadata endpoint is always rooted.

### DIFF
--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
@@ -17,6 +17,7 @@ import com.microsoft.azure.kusto.data.instrumentation.TraceableAttributes;
 import com.microsoft.azure.kusto.data.instrumentation.MonitoredActivity;
 import com.microsoft.azure.kusto.data.req.RequestUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.utils.URIBuilder;
 import org.jetbrains.annotations.Nullable;
 import reactor.core.publisher.Mono;
 
@@ -127,7 +128,11 @@ public class CloudInfo implements TraceableAttributes, Serializable {
         CloudInfo result;
         HttpClient localHttpClient = givenHttpClient == null ? HttpClientFactory.create(null) : givenHttpClient;
         try {
-            HttpRequest request = new HttpRequest(HttpMethod.GET, UriUtils.appendPathToUri(clusterUrl, METADATA_ENDPOINT));
+            // Metadata endpoint is always on the root of the cluster
+            URIBuilder metadataEndpointUriBuilder = new URIBuilder(clusterUrl);
+            metadataEndpointUriBuilder.setPath(METADATA_ENDPOINT);
+
+            HttpRequest request = new HttpRequest(HttpMethod.GET, metadataEndpointUriBuilder.build().toString());
             request.setHeader(HttpHeaderName.ACCEPT_ENCODING, "gzip,deflate");
             request.setHeader(HttpHeaderName.ACCEPT, "application/json");
 

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
@@ -17,7 +17,6 @@ import com.microsoft.azure.kusto.data.instrumentation.TraceableAttributes;
 import com.microsoft.azure.kusto.data.instrumentation.MonitoredActivity;
 import com.microsoft.azure.kusto.data.req.RequestUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.utils.URIBuilder;
 import org.jetbrains.annotations.Nullable;
 import reactor.core.publisher.Mono;
 
@@ -129,10 +128,7 @@ public class CloudInfo implements TraceableAttributes, Serializable {
         HttpClient localHttpClient = givenHttpClient == null ? HttpClientFactory.create(null) : givenHttpClient;
         try {
             // Metadata endpoint is always on the root of the cluster
-            URIBuilder metadataEndpointUriBuilder = new URIBuilder(clusterUrl);
-            metadataEndpointUriBuilder.setPath(METADATA_ENDPOINT);
-
-            HttpRequest request = new HttpRequest(HttpMethod.GET, metadataEndpointUriBuilder.build().toString());
+            HttpRequest request = new HttpRequest(HttpMethod.GET, UriUtils.setPathForUri(clusterUrl, METADATA_ENDPOINT));
             request.setHeader(HttpHeaderName.ACCEPT_ENCODING, "gzip,deflate");
             request.setHeader(HttpHeaderName.ACCEPT, "application/json");
 

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
@@ -677,6 +677,7 @@ class E2ETest {
 
     }
 
+    @Disabled("This test is disabled because it relies on the path part of the cluster Uri which we now ignore")
     @Test
     void testNoRedirectsCloudFail() {
         KustoTrustedEndpoints.addTrustedHosts(Collections.singletonList(new MatchRule("statusreturner.azurewebsites.net", false)), false);


### PR DESCRIPTION
### Fixed
Auth metadata endpoint is always relative to the root of the cluster