### PR TITLE
Ingest module async implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
 ### Added
 - The SDK now provides Reactor Core-based asynchronous APIs for all query, management, streaming query/ingestion (StreamingClient) endpoints,
 enabling non-blocking operations. You can read more about Reactor Core and [Mono type here](https://projectreactor.io/docs/core/release/api/).
+- The SDK now provides Reactor Core-based asynchronous APIs for all queued and streaming ingestion endpoints,
+  enabling non-blocking operations.
 
 ### Changed
 - [BREAKING] All synchronous query/management, streaming query/ingestion (StreamingClient) APIs now delegate to their asynchronous counterparts
 internally and block for results.
+- [BREAKING] All synchronous queued and streaming ingestion APIs now delegate to their asynchronous counterparts
+  internally and block for results.
 
 ## [6.0.0-ALPHA-01] - 2024-11-27
 ### Added

--- a/data/src/main/java/com/microsoft/azure/kusto/data/ExponentialRetry.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/ExponentialRetry.java
@@ -12,7 +12,7 @@ import com.microsoft.azure.kusto.data.exceptions.KustoDataExceptionBase;
 import reactor.util.annotation.Nullable;
 import reactor.util.retry.Retry;
 
-public class ExponentialRetry<E1 extends Throwable, E2 extends Throwable> {
+public class ExponentialRetry {
     private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final int maxAttempts;
@@ -35,38 +35,6 @@ public class ExponentialRetry<E1 extends Throwable, E2 extends Throwable> {
         this.maxAttempts = other.maxAttempts;
         this.sleepBaseSecs = other.sleepBaseSecs;
         this.maxJitterSecs = other.maxJitterSecs;
-    }
-
-    // Caller should throw only permanent errors, returning null if a retry is needed
-    public <T> T execute(KustoCheckedFunction<Integer, T, E1, E2> function) throws E1, E2 {
-        for (int currentAttempt = 0; currentAttempt < maxAttempts; currentAttempt++) {
-            log.info("execute: Attempt {}", currentAttempt);
-
-            try {
-                T result = function.apply(currentAttempt);
-                if (result != null) {
-                    return result;
-                }
-            } catch (Exception e) {
-                log.error("execute: Error is permanent, stopping", e);
-                throw e;
-            }
-
-            double currentSleepSecs = sleepBaseSecs * (float) Math.pow(2, currentAttempt);
-            double jitterSecs = (float) Math.random() * maxJitterSecs;
-            double sleepMs = (currentSleepSecs + jitterSecs) * 1000;
-
-            log.info("execute: Attempt {} failed, trying again after sleep of {} seconds", currentAttempt, sleepMs / 1000);
-
-            try {
-                Thread.sleep((long) sleepMs);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException("execute: Interrupted while sleeping", e);
-            }
-        }
-
-        return null;
     }
 
     /**

--- a/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/auth/CloudInfo.java
@@ -68,7 +68,7 @@ public class CloudInfo implements TraceableAttributes, Serializable {
     private final String kustoServiceResourceId;
     private final String firstPartyAuthorityUrl;
     private static final int ATTEMPT_COUNT = 3;
-    private static final Retry RETRY_CONFIG = new ExponentialRetry<>(ATTEMPT_COUNT).retry(null);
+    private static final Retry RETRY_CONFIG = new ExponentialRetry(ATTEMPT_COUNT).retry(null);
 
     public CloudInfo(boolean loginMfaRequired, String loginEndpoint, String kustoClientAppId, String kustoClientRedirectUri, String kustoServiceResourceId,
             String firstPartyAuthorityUrl) {

--- a/ingest/pom.xml
+++ b/ingest/pom.xml
@@ -109,6 +109,9 @@
                         <dependency>com.microsoft.azure:msal4j:jar</dependency>
                         <dependency>io.projectreactor:reactor-core:jar</dependency>
                         <dependency>com.fasterxml.jackson.core:jackson-core:jar</dependency>
+                        <dependency>io.netty:netty-buffer:jar</dependency>
+                        <dependency>io.netty:netty-codec:jar</dependency>
+                        <dependency>io.netty:netty-transport:jar</dependency>
                     </ignoredUsedUndeclaredDependencies>
                     <ignoreNonCompile>true</ignoreNonCompile>
                     <ignoredNonTestScopedDependencies>
@@ -280,6 +283,13 @@
             <artifactId>kusto-data</artifactId>
             <version>6.0.0</version>
             <scope>compile</scope>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/io.projectreactor/reactor-test -->
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <version>${reactor-test.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClient.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClient.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.kusto.ingest.source.BlobSourceInfo;
 import com.microsoft.azure.kusto.ingest.source.FileSourceInfo;
 import com.microsoft.azure.kusto.ingest.source.ResultSetSourceInfo;
 import com.microsoft.azure.kusto.ingest.source.StreamSourceInfo;
+import reactor.core.publisher.Mono;
 
 import java.io.Closeable;
 
@@ -31,6 +32,8 @@ public interface IngestClient extends Closeable {
     IngestionResult ingestFromFile(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties)
             throws IngestionClientException, IngestionServiceException;
 
+    Mono<IngestionResult> ingestFromFileAsync(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties);
+
     /**
      * <p>Ingest data from a blob storage into Kusto database.</p>
      * This method ingests the data from a given blob, described in {@code blobSourceInfo}, into Kusto database,
@@ -46,6 +49,8 @@ public interface IngestClient extends Closeable {
      */
     IngestionResult ingestFromBlob(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties)
             throws IngestionClientException, IngestionServiceException;
+
+    Mono<IngestionResult> ingestFromBlobAsync(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties);
 
     /**
      * <p>Ingest data from a Result Set into Kusto database.</p>
@@ -66,6 +71,8 @@ public interface IngestClient extends Closeable {
     IngestionResult ingestFromResultSet(ResultSetSourceInfo resultSetSourceInfo, IngestionProperties ingestionProperties)
             throws IngestionClientException, IngestionServiceException;
 
+    Mono<IngestionResult> ingestFromResultSetAsync(ResultSetSourceInfo resultSetSourceInfo, IngestionProperties ingestionProperties);
+
     /**
      * <p>Ingest data from an input stream, into Kusto database.</p>
      * This method ingests the data from a given input stream, described in {@code streamSourceInfo}, into Kusto database,
@@ -81,4 +88,6 @@ public interface IngestClient extends Closeable {
      */
     IngestionResult ingestFromStream(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties)
             throws IngestionClientException, IngestionServiceException;
+
+    Mono<IngestionResult> ingestFromStreamAsync(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties);
 }

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientBase.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientBase.java
@@ -1,19 +1,17 @@
 package com.microsoft.azure.kusto.ingest;
 
-import com.microsoft.azure.kusto.data.exceptions.ExceptionUtils;
-import com.microsoft.azure.kusto.ingest.source.CompressionType;
-import org.apache.http.conn.util.InetAddressUtils;
-
-import java.io.IOException;
-import java.net.URI;
-import com.microsoft.azure.kusto.data.instrumentation.SupplierTwoExceptions;
-import com.microsoft.azure.kusto.data.instrumentation.TraceableAttributes;
 import com.microsoft.azure.kusto.data.instrumentation.MonitoredActivity;
-import com.microsoft.azure.kusto.ingest.exceptions.IngestionClientException;
-import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException;
+import com.microsoft.azure.kusto.data.instrumentation.TraceableAttributes;
 import com.microsoft.azure.kusto.ingest.result.IngestionResult;
-import com.microsoft.azure.kusto.ingest.source.*;
+import com.microsoft.azure.kusto.ingest.source.BlobSourceInfo;
+import com.microsoft.azure.kusto.ingest.source.CompressionType;
+import com.microsoft.azure.kusto.ingest.source.FileSourceInfo;
+import com.microsoft.azure.kusto.ingest.source.ResultSetSourceInfo;
+import com.microsoft.azure.kusto.ingest.source.StreamSourceInfo;
+import org.apache.http.conn.util.InetAddressUtils;
+import reactor.core.publisher.Mono;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,16 +57,18 @@ public abstract class IngestClientBase implements IngestClient {
         return isLocalFlag || isIPFlag || authority.equalsIgnoreCase("onebox.dev.kusto.windows.net");
     }
 
-    protected abstract IngestionResult ingestFromFileImpl(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException;
+    public IngestionResult ingestFromFile(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties) {
+        return ingestFromFileAsync(fileSourceInfo, ingestionProperties).block();
+    }
 
-    public IngestionResult ingestFromFile(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException {
-        // trace ingestFromFile
-        return MonitoredActivity.invoke(
-                (SupplierTwoExceptions<IngestionResult, IngestionClientException, IngestionServiceException>) () -> ingestFromFileImpl(fileSourceInfo,
+    protected abstract Mono<IngestionResult> ingestFromFileAsyncImpl(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties);
+
+    public Mono<IngestionResult> ingestFromFileAsync(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties) {
+        // trace ingestFromFileAsync
+        return Mono.defer(() -> MonitoredActivity.wrap(
+                ingestFromFileAsyncImpl(fileSourceInfo,
                         ingestionProperties),
-                getClientType().concat(".ingestFromFile"));
+                getClientType().concat(".ingestFromFile")));
     }
 
     /**
@@ -79,21 +79,21 @@ public abstract class IngestClientBase implements IngestClient {
      * @param blobSourceInfo      The specific SourceInfo to be ingested
      * @param ingestionProperties Settings used to customize the ingestion operation
      * @return {@link IngestionResult} object including the ingestion result
-     * @throws IngestionClientException  An exception originating from a client activity
-     * @throws IngestionServiceException An exception returned from the service
      * @see BlobSourceInfo
      * @see IngestionProperties
      */
-    protected abstract IngestionResult ingestFromBlobImpl(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException;
+    public IngestionResult ingestFromBlob(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties) {
+        return ingestFromBlobAsync(blobSourceInfo, ingestionProperties).block();
+    }
 
-    public IngestionResult ingestFromBlob(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException {
+    protected abstract Mono<IngestionResult> ingestFromBlobAsyncImpl(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties);
+
+    public Mono<IngestionResult> ingestFromBlobAsync(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties) {
         // trace ingestFromBlob
-        return MonitoredActivity.invoke(
-                (SupplierTwoExceptions<IngestionResult, IngestionClientException, IngestionServiceException>) () -> ingestFromBlobImpl(blobSourceInfo,
+        return Mono.defer(() -> MonitoredActivity.wrap(
+                ingestFromBlobAsyncImpl(blobSourceInfo,
                         ingestionProperties),
-                getClientType().concat(".ingestFromBlob"));
+                getClientType().concat(".ingestFromBlob")));
     }
 
     /**
@@ -107,21 +107,21 @@ public abstract class IngestClientBase implements IngestClient {
      * @param resultSetSourceInfo The specific SourceInfo to be ingested
      * @param ingestionProperties Settings used to customize the ingestion operation
      * @return {@link IngestionResult} object including the ingestion result
-     * @throws IngestionClientException  An exception originating from a client activity
-     * @throws IngestionServiceException An exception returned from the service
      * @see ResultSetSourceInfo
      * @see IngestionProperties
      */
-    protected abstract IngestionResult ingestFromResultSetImpl(ResultSetSourceInfo resultSetSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException;
+    public IngestionResult ingestFromResultSet(ResultSetSourceInfo resultSetSourceInfo, IngestionProperties ingestionProperties) {
+        return ingestFromResultSetAsync(resultSetSourceInfo, ingestionProperties).block();
+    }
 
-    public IngestionResult ingestFromResultSet(ResultSetSourceInfo resultSetSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException {
+    protected abstract Mono<IngestionResult> ingestFromResultSetAsyncImpl(ResultSetSourceInfo resultSetSourceInfo, IngestionProperties ingestionProperties);
+
+    public Mono<IngestionResult> ingestFromResultSetAsync(ResultSetSourceInfo resultSetSourceInfo, IngestionProperties ingestionProperties) {
         // trace ingestFromResultSet
-        return MonitoredActivity.invoke(
-                (SupplierTwoExceptions<IngestionResult, IngestionClientException, IngestionServiceException>) () -> ingestFromResultSetImpl(resultSetSourceInfo,
+        return Mono.defer(() -> MonitoredActivity.wrap(
+                ingestFromResultSetAsyncImpl(resultSetSourceInfo,
                         ingestionProperties),
-                getClientType().concat(".ingestFromResultSet"));
+                getClientType().concat(".ingestFromResultSet")));
     }
 
     /**
@@ -132,27 +132,21 @@ public abstract class IngestClientBase implements IngestClient {
      * @param streamSourceInfo    The specific SourceInfo to be ingested
      * @param ingestionProperties Settings used to customize the ingestion operation
      * @return {@link IngestionResult} object including the ingestion result
-     * @throws IngestionClientException  An exception originating from a client activity
-     * @throws IngestionServiceException An exception returned from the service
      * @see StreamSourceInfo
      * @see IngestionProperties
      */
-    protected abstract IngestionResult ingestFromStreamImpl(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException, IOException;
+    public IngestionResult ingestFromStream(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties) {
+        return ingestFromStreamAsync(streamSourceInfo, ingestionProperties).block();
+    }
 
-    public IngestionResult ingestFromStream(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException {
+    protected abstract Mono<IngestionResult> ingestFromStreamAsyncImpl(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties);
+
+    public Mono<IngestionResult> ingestFromStreamAsync(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties) {
         // trace ingestFromStream
-        return MonitoredActivity.invoke(
-                (SupplierTwoExceptions<IngestionResult, IngestionClientException, IngestionServiceException>) () -> {
-                    try {
-                        return ingestFromStreamImpl(streamSourceInfo,
-                                ingestionProperties);
-                    } catch (IOException e) {
-                        throw new IngestionServiceException(ExceptionUtils.getMessageEx(e), e);
-                    }
-                },
-                getClientType().concat(".ingestFromStream"));
+        return Mono.defer(() -> MonitoredActivity.wrap(
+                ingestFromStreamAsyncImpl(streamSourceInfo,
+                        ingestionProperties),
+                getClientType().concat(".ingestFromStream")));
     }
 
     protected Map<String, String> getIngestionTraceAttributes(TraceableAttributes sourceInfo, TraceableAttributes ingestionProperties) {

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientImpl.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/QueuedIngestClientImpl.java
@@ -9,14 +9,27 @@ import com.azure.data.tables.models.TableServiceException;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.common.policy.RequestRetryOptions;
 import com.azure.storage.queue.models.QueueStorageException;
-import com.microsoft.azure.kusto.data.*;
+import com.microsoft.azure.kusto.data.Client;
+import com.microsoft.azure.kusto.data.ClientDetails;
+import com.microsoft.azure.kusto.data.ClientFactory;
+import com.microsoft.azure.kusto.data.Ensure;
+import com.microsoft.azure.kusto.data.UriUtils;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
 import com.microsoft.azure.kusto.data.http.HttpClientFactory;
 import com.microsoft.azure.kusto.data.http.HttpClientProperties;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionClientException;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException;
-import com.microsoft.azure.kusto.ingest.result.*;
-import com.microsoft.azure.kusto.ingest.source.*;
+import com.microsoft.azure.kusto.ingest.result.IngestionResult;
+import com.microsoft.azure.kusto.ingest.result.IngestionStatus;
+import com.microsoft.azure.kusto.ingest.result.IngestionStatusInTableDescription;
+import com.microsoft.azure.kusto.ingest.result.IngestionStatusResult;
+import com.microsoft.azure.kusto.ingest.result.OperationStatus;
+import com.microsoft.azure.kusto.ingest.result.TableReportIngestionResult;
+import com.microsoft.azure.kusto.ingest.source.BlobSourceInfo;
+import com.microsoft.azure.kusto.ingest.source.CompressionType;
+import com.microsoft.azure.kusto.ingest.source.FileSourceInfo;
+import com.microsoft.azure.kusto.ingest.source.ResultSetSourceInfo;
+import com.microsoft.azure.kusto.ingest.source.StreamSourceInfo;
 import com.microsoft.azure.kusto.ingest.utils.IngestionUtils;
 import com.microsoft.azure.kusto.ingest.utils.SecurityUtils;
 import com.microsoft.azure.kusto.ingest.utils.TableWithSas;
@@ -24,6 +37,8 @@ import com.univocity.parsers.csv.CsvRoutines;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -34,6 +49,7 @@ import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class QueuedIngestClientImpl extends IngestClientBase implements QueuedIngestClient {
@@ -80,160 +96,171 @@ public class QueuedIngestClientImpl extends IngestClientBase implements QueuedIn
     }
 
     @Override
-    protected IngestionResult ingestFromBlobImpl(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException {
-        // Argument validation:
+    protected Mono<IngestionResult> ingestFromBlobAsyncImpl(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties) {
         Ensure.argIsNotNull(blobSourceInfo, "blobSourceInfo");
         Ensure.argIsNotNull(ingestionProperties, "ingestionProperties");
-
         blobSourceInfo.validate();
         ingestionProperties.validate();
+        ingestionProperties.setAuthorizationContextToken(resourceManager.getIdentityToken());
 
+        // Create the ingestion message
+        IngestionBlobInfo ingestionBlobInfo = new IngestionBlobInfo(blobSourceInfo.getBlobPath(),
+                ingestionProperties.getDatabaseName(), ingestionProperties.getTableName(), this.applicationForTracing,
+                this.clientVersionForTracing);
+        String urlWithoutSecrets = SecurityUtils.removeSecretsFromUrl(blobSourceInfo.getBlobPath());
+        if (blobSourceInfo.getRawSizeInBytes() > 0L) {
+            ingestionBlobInfo.setRawDataSize(blobSourceInfo.getRawSizeInBytes());
+        } else {
+            log.warn("Blob '{}' was sent for ingestion without specifying its raw data size", urlWithoutSecrets);
+        }
+
+        Map<String, String> properties;
         try {
-            ingestionProperties.setAuthorizationContextToken(resourceManager.getIdentityToken());
-            List<IngestionStatusInTableDescription> tableStatuses = new LinkedList<>();
-
-            // Create the ingestion message
-            IngestionBlobInfo ingestionBlobInfo = new IngestionBlobInfo(blobSourceInfo.getBlobPath(),
-                    ingestionProperties.getDatabaseName(), ingestionProperties.getTableName(), this.applicationForTracing,
-                    this.clientVersionForTracing);
-            String urlWithoutSecrets = SecurityUtils.removeSecretsFromUrl(blobSourceInfo.getBlobPath());
-            if (blobSourceInfo.getRawSizeInBytes() > 0L) {
-                ingestionBlobInfo.setRawDataSize(blobSourceInfo.getRawSizeInBytes());
-            } else {
-                log.warn("Blob '{}' was sent for ingestion without specifying its raw data size", urlWithoutSecrets);
-            }
-
-            ingestionBlobInfo.setReportLevel(ingestionProperties.getReportLevel().getKustoValue());
-            ingestionBlobInfo.setReportMethod(ingestionProperties.getReportMethod().getKustoValue());
-            ingestionBlobInfo.setFlushImmediately(ingestionProperties.getFlushImmediately());
-            ingestionBlobInfo.setValidationPolicy(ingestionProperties.getValidationPolicy());
-            ingestionBlobInfo.setAdditionalProperties(ingestionProperties.getIngestionProperties());
-            if (blobSourceInfo.getSourceId() != null) {
-                ingestionBlobInfo.setId(blobSourceInfo.getSourceId());
-            }
-
-            String id = ingestionBlobInfo.getId().toString();
-            IngestionStatus status = new IngestionStatus();
-            status.setDatabase(ingestionProperties.getDatabaseName());
-            status.setTable(ingestionProperties.getTableName());
-            status.setStatus(OperationStatus.Queued);
-            status.setUpdatedOn(Instant.now());
-            status.setIngestionSourceId(ingestionBlobInfo.getId());
-            status.setIngestionSourcePath(urlWithoutSecrets);
-            boolean reportToTable = ingestionProperties.getReportLevel() != IngestionProperties.IngestionReportLevel.NONE &&
-                    ingestionProperties.getReportMethod() != IngestionProperties.IngestionReportMethod.QUEUE;
-            if (reportToTable) {
-                status.setStatus(OperationStatus.Pending);
-                TableWithSas statusTable = resourceManager
-                        .getStatusTable();
-                IngestionStatusInTableDescription ingestionStatusInTable = new IngestionStatusInTableDescription();
-                ingestionStatusInTable.setTableClient(statusTable.getTable());
-                ingestionStatusInTable.setTableConnectionString(statusTable.getUri());
-                ingestionStatusInTable.setPartitionKey(ingestionBlobInfo.getId().toString());
-                ingestionStatusInTable.setRowKey(ingestionBlobInfo.getId().toString());
-                ingestionBlobInfo.setIngestionStatusInTable(ingestionStatusInTable);
-                azureStorageClient.azureTableInsertEntity(statusTable.getTable(), new TableEntity(id, id).setProperties(status.getEntityProperties()));
-                tableStatuses.add(ingestionBlobInfo.getIngestionStatusInTable());
-            }
-
-            ResourceAlgorithms.postToQueueWithRetries(resourceManager, azureStorageClient, ingestionBlobInfo);
-
-            return reportToTable
-                    ? new TableReportIngestionResult(tableStatuses)
-                    : new IngestionStatusResult(status);
-        } catch (BlobStorageException | QueueStorageException | TableServiceException e) {
-            throw new IngestionServiceException("Failed to ingest from blob", e);
-        } catch (IOException | URISyntaxException e) {
+            properties = ingestionProperties.getIngestionProperties();
+        } catch (IOException e) {
             throw new IngestionClientException("Failed to ingest from blob", e);
         }
+
+        ingestionBlobInfo.setReportLevel(ingestionProperties.getReportLevel().getKustoValue());
+        ingestionBlobInfo.setReportMethod(ingestionProperties.getReportMethod().getKustoValue());
+        ingestionBlobInfo.setFlushImmediately(ingestionProperties.getFlushImmediately());
+        ingestionBlobInfo.setValidationPolicy(ingestionProperties.getValidationPolicy());
+        ingestionBlobInfo.setAdditionalProperties(properties);
+        if (blobSourceInfo.getSourceId() != null) {
+            ingestionBlobInfo.setId(blobSourceInfo.getSourceId());
+        }
+
+        String id = ingestionBlobInfo.getId().toString();
+        IngestionStatus status = new IngestionStatus();
+        status.setDatabase(ingestionProperties.getDatabaseName());
+        status.setTable(ingestionProperties.getTableName());
+        status.setStatus(OperationStatus.Queued);
+        status.setUpdatedOn(Instant.now());
+        status.setIngestionSourceId(ingestionBlobInfo.getId());
+        status.setIngestionSourcePath(urlWithoutSecrets);
+
+        boolean reportToTable = ingestionProperties.getReportLevel() != IngestionProperties.IngestionReportLevel.NONE &&
+                ingestionProperties.getReportMethod() != IngestionProperties.IngestionReportMethod.QUEUE;
+        List<IngestionStatusInTableDescription> tableStatuses = new LinkedList<>();
+
+        if (reportToTable) {
+            status.setStatus(OperationStatus.Pending);
+            TableWithSas statusTable = resourceManager.getStatusTable();
+            IngestionStatusInTableDescription ingestionStatusInTable = new IngestionStatusInTableDescription();
+            ingestionStatusInTable.setAsyncTableClient(statusTable.getTableAsyncClient());
+            ingestionStatusInTable.setTableConnectionString(statusTable.getUri());
+            ingestionStatusInTable.setPartitionKey(ingestionBlobInfo.getId().toString());
+            ingestionStatusInTable.setRowKey(ingestionBlobInfo.getId().toString());
+            ingestionBlobInfo.setIngestionStatusInTable(ingestionStatusInTable);
+
+            return azureStorageClient
+                    .azureTableInsertEntity(statusTable.getTableAsyncClient(), new TableEntity(id, id).setProperties(status.getEntityProperties()))
+                    .doOnTerminate(() -> tableStatuses.add(ingestionBlobInfo.getIngestionStatusInTable()))
+                    .then(ResourceAlgorithms.postToQueueWithRetriesAsync(resourceManager, azureStorageClient, ingestionBlobInfo)
+                            .thenReturn((IngestionResult) new TableReportIngestionResult(tableStatuses)))
+                    .onErrorMap(e -> {
+                        if (e instanceof BlobStorageException || e instanceof QueueStorageException || e instanceof TableServiceException) {
+                            return new IngestionServiceException("Failed to ingest from blob", (Exception) e);
+                        } else if (e instanceof URISyntaxException) {
+                            return new IngestionClientException("Failed to ingest from blob", e);
+                        } else {
+                            return e;
+                        }
+                    });
+        }
+
+        return ResourceAlgorithms.postToQueueWithRetriesAsync(resourceManager, azureStorageClient, ingestionBlobInfo)
+                .thenReturn(new IngestionStatusResult(status));
     }
 
     @Override
-    protected IngestionResult ingestFromFileImpl(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException {
-        // Argument validation:
+    protected Mono<IngestionResult> ingestFromFileAsyncImpl(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties) {
         Ensure.argIsNotNull(fileSourceInfo, "fileSourceInfo");
         Ensure.argIsNotNull(ingestionProperties, "ingestionProperties");
-
         fileSourceInfo.validate();
         ingestionProperties.validate();
 
+        String filePath = fileSourceInfo.getFilePath();
         try {
-            String filePath = fileSourceInfo.getFilePath();
             Ensure.fileExists(filePath);
-            CompressionType sourceCompressionType = IngestionUtils.getCompression(filePath);
-            IngestionProperties.DataFormat dataFormat = ingestionProperties.getDataFormat();
-            boolean shouldCompress = shouldCompress(sourceCompressionType, dataFormat);
-
-            File file = new File(filePath);
-            String blobName = genBlobName(
-                    file.getName(),
-                    ingestionProperties.getDatabaseName(),
-                    ingestionProperties.getTableName(),
-                    dataFormat.getKustoValue(), // Used to use an empty string if the DataFormat was empty. Now it can't be empty, with a default of CSV.
-                    shouldCompress ? CompressionType.gz : sourceCompressionType);
-
-            String blobPath = ResourceAlgorithms.uploadLocalFileWithRetries(resourceManager, azureStorageClient, file, blobName, shouldCompress);
-
-            long rawDataSize = fileSourceInfo.getRawSizeInBytes() > 0L ? fileSourceInfo.getRawSizeInBytes()
-                    : estimateFileRawSize(filePath, ingestionProperties.getDataFormat().isCompressible());
-
-            BlobSourceInfo blobSourceInfo = new BlobSourceInfo(blobPath, rawDataSize, fileSourceInfo.getSourceId());
-
-            return ingestFromBlob(blobSourceInfo, ingestionProperties);
-        } catch (BlobStorageException e) {
-            throw new IngestionServiceException("Failed to ingest from file", e);
         } catch (IOException e) {
             throw new IngestionClientException("Failed to ingest from file", e);
         }
+
+        CompressionType sourceCompressionType = IngestionUtils.getCompression(filePath);
+        IngestionProperties.DataFormat dataFormat = ingestionProperties.getDataFormat();
+        boolean shouldCompress = shouldCompress(sourceCompressionType, dataFormat);
+
+        File file = new File(filePath);
+        String blobName = genBlobName(
+                file.getName(),
+                ingestionProperties.getDatabaseName(),
+                ingestionProperties.getTableName(),
+                dataFormat.getKustoValue(), // Used to use an empty string if the DataFormat was empty. Now it can't be empty, with a default of
+                // CSV.
+                shouldCompress ? CompressionType.gz : sourceCompressionType);
+
+        return ResourceAlgorithms.uploadLocalFileWithRetriesAsync(resourceManager, azureStorageClient, file, blobName, shouldCompress)
+                .flatMap(blobPath -> {
+                    long rawDataSize = fileSourceInfo.getRawSizeInBytes() > 0L ? fileSourceInfo.getRawSizeInBytes()
+                            : estimateFileRawSize(filePath, ingestionProperties.getDataFormat().isCompressible());
+                    BlobSourceInfo blobSourceInfo = new BlobSourceInfo(blobPath, rawDataSize, fileSourceInfo.getSourceId());
+                    return ingestFromBlobAsync(blobSourceInfo, ingestionProperties);
+                })
+                .onErrorMap(BlobStorageException.class, e -> new IngestionServiceException("Failed to ingest from file", e));
     }
 
     @Override
-    protected IngestionResult ingestFromStreamImpl(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException {
-        // Argument validation:
+    protected Mono<IngestionResult> ingestFromStreamAsyncImpl(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties) {
         Ensure.argIsNotNull(streamSourceInfo, "streamSourceInfo");
         Ensure.argIsNotNull(ingestionProperties, "ingestionProperties");
-
         streamSourceInfo.validate();
         ingestionProperties.validate();
 
+        if (streamSourceInfo.getStream() == null) {
+            throw new IngestionClientException("The provided stream is null.");
+        }
+
         try {
-            IngestionResult ingestionResult;
-            if (streamSourceInfo.getStream() == null) {
-                throw new IngestionClientException("The provided stream is null.");
-            } else if (streamSourceInfo.getStream().available() <= 0) {
+            if (streamSourceInfo.getStream().available() <= 0) {
                 throw new IngestionClientException("The provided stream is empty.");
             }
-            IngestionProperties.DataFormat dataFormat = ingestionProperties.getDataFormat();
-            boolean shouldCompress = shouldCompress(streamSourceInfo.getCompressionType(), dataFormat);
-
-            String blobName = genBlobName(
-                    "StreamUpload",
-                    ingestionProperties.getDatabaseName(),
-                    ingestionProperties.getTableName(),
-                    dataFormat.getKustoValue(), // Used to use an empty string if the DataFormat was empty. Now it can't be empty, with a default of CSV.
-                    shouldCompress ? CompressionType.gz : streamSourceInfo.getCompressionType());
-
-            String blobPath = ResourceAlgorithms.uploadStreamToBlobWithRetries(resourceManager,
-                    azureStorageClient,
-                    streamSourceInfo.getStream(),
-                    blobName,
-                    shouldCompress);
-
-            BlobSourceInfo blobSourceInfo = new BlobSourceInfo(blobPath, streamSourceInfo.getRawSizeInBytes(), streamSourceInfo.getSourceId());
-
-            ingestionResult = ingestFromBlob(blobSourceInfo, ingestionProperties);
-            if (!streamSourceInfo.isLeaveOpen()) {
-                streamSourceInfo.getStream().close();
-            }
-            return ingestionResult;
-        } catch (BlobStorageException e) {
-            throw new IngestionServiceException("Failed to ingest from stream", e);
         } catch (IOException e) {
-            throw new IngestionClientException("Failed to ingest from stream", e);
+            throw new IngestionClientException("The provided stream is empty.");
         }
+
+        IngestionProperties.DataFormat dataFormat = ingestionProperties.getDataFormat();
+        boolean shouldCompress = shouldCompress(streamSourceInfo.getCompressionType(), dataFormat);
+
+        String blobName = genBlobName(
+                "StreamUpload",
+                ingestionProperties.getDatabaseName(),
+                ingestionProperties.getTableName(),
+                dataFormat.getKustoValue(), // Used to use an empty string if the DataFormat was empty. Now it can't be empty, with a default of
+                // CSV.
+                shouldCompress ? CompressionType.gz : streamSourceInfo.getCompressionType());
+
+        return ResourceAlgorithms.uploadStreamToBlobWithRetriesAsync(resourceManager,
+                azureStorageClient,
+                streamSourceInfo.getStream(),
+                blobName,
+                shouldCompress)
+                .flatMap(blobPath -> {
+                    BlobSourceInfo blobSourceInfo = new BlobSourceInfo(blobPath, streamSourceInfo.getRawSizeInBytes(),
+                            streamSourceInfo.getSourceId());
+                    return ingestFromBlobAsync(blobSourceInfo, ingestionProperties);
+                })
+                .onErrorMap(BlobStorageException.class, e -> new IngestionServiceException("Failed to ingest from stream", e))
+                .doFinally(signalType -> {
+                    if (!streamSourceInfo.isLeaveOpen()) {
+                        try {
+                            streamSourceInfo.getStream().close();
+                        } catch (IOException e) {
+                            throw new IngestionClientException("Failed to close stream after ingestion", e);
+                        }
+                    }
+                });
+
     }
 
     @Override
@@ -257,27 +284,25 @@ public class QueuedIngestClientImpl extends IngestClientBase implements QueuedIn
     }
 
     @Override
-    protected IngestionResult ingestFromResultSetImpl(ResultSetSourceInfo resultSetSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException {
-        // Argument validation:
+    protected Mono<IngestionResult> ingestFromResultSetAsyncImpl(ResultSetSourceInfo resultSetSourceInfo, IngestionProperties ingestionProperties) {
         Ensure.argIsNotNull(resultSetSourceInfo, "resultSetSourceInfo");
         Ensure.argIsNotNull(ingestionProperties, "ingestionProperties");
-
         resultSetSourceInfo.validate();
         ingestionProperties.validateResultSetProperties();
-        try {
+
+        return Mono.fromCallable(() -> {
             ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            new CsvRoutines().write(resultSetSourceInfo.getResultSet(), byteArrayOutputStream);
+            new CsvRoutines().write(resultSetSourceInfo.getResultSet(), byteArrayOutputStream); // TODO: CsvRoutines is not maintained from 2021. replace?
             byteArrayOutputStream.flush();
             ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
-
-            StreamSourceInfo streamSourceInfo = new StreamSourceInfo(byteArrayInputStream, false, resultSetSourceInfo.getSourceId());
-            return ingestFromStream(streamSourceInfo, ingestionProperties);
-        } catch (IOException ex) {
-            String msg = "Failed to read from ResultSet.";
-            log.error(msg, ex);
-            throw new IngestionClientException(msg, ex);
-        }
+            return new StreamSourceInfo(byteArrayInputStream, false, resultSetSourceInfo.getSourceId());
+        }).subscribeOn(Schedulers.boundedElastic())
+                .flatMap(streamSourceInfo -> ingestFromStreamAsync(streamSourceInfo, ingestionProperties))
+                .onErrorMap(IOException.class, e -> {
+                    String msg = "Failed to read from ResultSet.";
+                    log.error(msg, e);
+                    return new IngestionClientException(msg, e);
+                });
     }
 
     protected void setConnectionDataSource(String connectionDataSource) {

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/StreamingIngestClient.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/StreamingIngestClient.java
@@ -4,17 +4,20 @@
 package com.microsoft.azure.kusto.ingest;
 
 import com.azure.core.http.HttpClient;
-import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobAsyncClient;
 import com.azure.storage.blob.BlobClientBuilder;
 import com.azure.storage.blob.models.BlobStorageException;
-import com.microsoft.azure.kusto.data.*;
+import com.microsoft.azure.kusto.data.ClientFactory;
+import com.microsoft.azure.kusto.data.ClientRequestProperties;
+import com.microsoft.azure.kusto.data.Ensure;
+import com.microsoft.azure.kusto.data.StreamingClient;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
 import com.microsoft.azure.kusto.data.exceptions.DataClientException;
 import com.microsoft.azure.kusto.data.exceptions.DataServiceException;
 import com.microsoft.azure.kusto.data.exceptions.ExceptionUtils;
 import com.microsoft.azure.kusto.data.http.HttpClientProperties;
+import com.microsoft.azure.kusto.data.http.HttpStatus;
 import com.microsoft.azure.kusto.data.instrumentation.MonitoredActivity;
-import com.microsoft.azure.kusto.data.instrumentation.SupplierTwoExceptions;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionClientException;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException;
 import com.microsoft.azure.kusto.ingest.result.IngestionResult;
@@ -30,13 +33,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
-import java.io.*;
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Objects;
-import java.util.zip.GZIPOutputStream;
 
 public class StreamingIngestClient extends IngestClientBase implements IngestClient {
 
@@ -84,70 +88,64 @@ public class StreamingIngestClient extends IngestClientBase implements IngestCli
     }
 
     @Override
-    protected IngestionResult ingestFromFileImpl(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException {
+    protected Mono<IngestionResult> ingestFromFileAsyncImpl(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties) {
         Ensure.argIsNotNull(fileSourceInfo, "fileSourceInfo");
         Ensure.argIsNotNull(ingestionProperties, "ingestionProperties");
-
         fileSourceInfo.validate();
         ingestionProperties.validate();
 
         try {
             StreamSourceInfo streamSourceInfo = IngestionUtils.fileToStream(fileSourceInfo, false, ingestionProperties.getDataFormat());
-            return ingestFromStream(streamSourceInfo, ingestionProperties);
-        } catch (FileNotFoundException e) {
+            return ingestFromStreamAsync(streamSourceInfo, ingestionProperties);
+        } catch (IOException e) {
             log.error("File not found when ingesting a file.", e);
             throw new IngestionClientException("IO exception - check file path.", e);
         }
     }
 
     @Override
-    protected IngestionResult ingestFromBlobImpl(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException {
+    protected Mono<IngestionResult> ingestFromBlobAsyncImpl(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties) {
         Ensure.argIsNotNull(blobSourceInfo, "blobSourceInfo");
         Ensure.argIsNotNull(ingestionProperties, "ingestionProperties");
-
         blobSourceInfo.validate();
         ingestionProperties.validate();
 
+        BlobAsyncClient blobAsyncClient;
         try {
-            BlobClient blobClient = new BlobClientBuilder().endpoint(blobSourceInfo.getBlobPath()).buildClient();
-            return ingestFromBlob(blobSourceInfo, ingestionProperties, blobClient, null);
+            blobAsyncClient = new BlobClientBuilder().endpoint(blobSourceInfo.getBlobPath()).buildAsyncClient();
+            return ingestFromBlobAsync(blobSourceInfo, ingestionProperties, blobAsyncClient, null)
+                    .onErrorMap(BlobStorageException.class, e -> {
+                        String msg = "Unexpected Storage error when ingesting a blob.";
+                        log.error(msg, e);
+                        return new IngestionClientException(msg, e);
+                    });
         } catch (IllegalArgumentException e) {
             String msg = "Unexpected error when ingesting a blob - Invalid blob path.";
-            log.error(msg, e);
-            throw new IngestionClientException(msg, e);
-        } catch (BlobStorageException e) {
-            String msg = "Unexpected Storage error when ingesting a blob.";
             log.error(msg, e);
             throw new IngestionClientException(msg, e);
         }
     }
 
     @Override
-    protected IngestionResult ingestFromResultSetImpl(ResultSetSourceInfo resultSetSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException {
-        // Argument validation:
+    protected Mono<IngestionResult> ingestFromResultSetAsyncImpl(ResultSetSourceInfo resultSetSourceInfo, IngestionProperties ingestionProperties) {
         Ensure.argIsNotNull(resultSetSourceInfo, "resultSetSourceInfo");
         Ensure.argIsNotNull(ingestionProperties, "ingestionProperties");
-
         resultSetSourceInfo.validate();
         ingestionProperties.validateResultSetProperties();
 
         try {
             StreamSourceInfo streamSourceInfo = IngestionUtils.resultSetToStream(resultSetSourceInfo);
-            return ingestFromStream(streamSourceInfo, ingestionProperties);
-        } catch (IOException ex) {
+            return ingestFromStreamAsync(streamSourceInfo, ingestionProperties);
+        } catch (IOException e) {
             String msg = "Failed to read from ResultSet.";
-            log.error(msg, ex);
-            throw new IngestionClientException(msg, ex);
+            log.error(msg, e);
+            throw new IngestionClientException(msg, e);
         }
     }
 
     @Override
-    protected IngestionResult ingestFromStreamImpl(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties)
-            throws IngestionClientException, IngestionServiceException {
-        return ingestFromStreamImpl(streamSourceInfo, ingestionProperties, null);
+    protected Mono<IngestionResult> ingestFromStreamAsyncImpl(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties) {
+        return ingestFromStreamImplAsync(streamSourceInfo, ingestionProperties, null);
     }
 
     @Override
@@ -155,140 +153,133 @@ public class StreamingIngestClient extends IngestClientBase implements IngestCli
         return CLASS_NAME;
     }
 
-    IngestionResult ingestFromStream(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties, @Nullable String clientRequestId)
-            throws IngestionClientException, IngestionServiceException {
-        // trace ingestFromStream
-        return MonitoredActivity.invoke(
-                (SupplierTwoExceptions<IngestionResult, IngestionClientException, IngestionServiceException>) () -> ingestFromStreamImpl(streamSourceInfo,
+    Mono<IngestionResult> ingestFromStreamAsync(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties, @Nullable String clientRequestId) {
+        // trace ingestFromStreamAsync
+        return MonitoredActivity.wrap(
+                ingestFromStreamImplAsync(streamSourceInfo,
                         ingestionProperties, clientRequestId),
                 getClientType().concat(".ingestFromStream"),
                 getIngestionTraceAttributes(streamSourceInfo, ingestionProperties));
     }
 
-    private IngestionResult ingestFromStreamImpl(StreamSourceInfo streamSourceInfo, IngestionProperties ingestionProperties, @Nullable String clientRequestId)
-            throws IngestionClientException, IngestionServiceException {
+    private Mono<IngestionResult> ingestFromStreamImplAsync(StreamSourceInfo streamSourceInfo,
+            IngestionProperties ingestionProperties,
+            @Nullable String clientRequestId) {
+
         Ensure.argIsNotNull(streamSourceInfo, "streamSourceInfo");
         Ensure.argIsNotNull(ingestionProperties, "ingestionProperties");
+        ingestionProperties.validate();
+        streamSourceInfo.validate();
 
         IngestionProperties.DataFormat dataFormat = ingestionProperties.getDataFormat();
 
-        streamSourceInfo.validate();
-        ingestionProperties.validate();
+        return (IngestClientBase.shouldCompress(streamSourceInfo.getCompressionType(), dataFormat)
+                ? IngestionUtils.compressStream(streamSourceInfo.getStream(), streamSourceInfo.isLeaveOpen())
+                : Mono.just(streamSourceInfo.getStream()))
+                        .subscribeOn(Schedulers.boundedElastic())
+                        .onErrorMap(IOException.class, e -> {
+                            String msg = ExceptionUtils.getMessageEx(e);
+                            log.error(msg, e);
+                            return new IngestionClientException(msg, e);
+                        })
+                        .flatMap(stream -> {
+                            ClientRequestProperties clientRequestProperties = null;
+                            if (StringUtils.isNotBlank(clientRequestId)) {
+                                clientRequestProperties = new ClientRequestProperties();
+                                clientRequestProperties.setClientRequestId(clientRequestId);
+                            }
 
-        ClientRequestProperties clientRequestProperties = null;
-        if (StringUtils.isNotBlank(clientRequestId)) {
-            clientRequestProperties = new ClientRequestProperties();
-            clientRequestProperties.setClientRequestId(clientRequestId);
-        }
-
-        try {
-            InputStream stream = IngestClientBase.shouldCompress(streamSourceInfo.getCompressionType(), dataFormat)
-                    ? compressStream(streamSourceInfo.getStream(), streamSourceInfo.isLeaveOpen())
-                    : streamSourceInfo.getStream();
-            log.debug("Executing streaming ingest");
-            this.streamingClient.executeStreamingIngest(ingestionProperties.getDatabaseName(),
-                    ingestionProperties.getTableName(),
-                    stream,
-                    clientRequestProperties,
-                    dataFormat.getKustoValue(),
-                    ingestionProperties.getIngestionMapping().getIngestionMappingReference(),
-                    !(streamSourceInfo.getCompressionType() == null || !streamSourceInfo.isLeaveOpen()));
-        } catch (DataClientException | IOException e) {
-            String msg = ExceptionUtils.getMessageEx(e);
-            log.error(msg, e);
-            throw new IngestionClientException(msg, e);
-        } catch (DataServiceException e) {
-            log.error(e.getMessage(), e);
-            throw new IngestionServiceException(e.getMessage(), e);
-        }
-
-        log.debug("Stream was ingested successfully.");
-        IngestionStatus ingestionStatus = new IngestionStatus();
-        ingestionStatus.status = OperationStatus.Succeeded;
-        ingestionStatus.table = ingestionProperties.getTableName();
-        ingestionStatus.database = ingestionProperties.getDatabaseName();
-        return new IngestionStatusResult(ingestionStatus);
+                            log.debug("Executing streaming ingest");
+                            return this.streamingClient.executeStreamingIngestAsync(
+                                    ingestionProperties.getDatabaseName(),
+                                    ingestionProperties.getTableName(),
+                                    stream,
+                                    clientRequestProperties,
+                                    dataFormat.getKustoValue(),
+                                    ingestionProperties.getIngestionMapping().getIngestionMappingReference(),
+                                    !(streamSourceInfo.getCompressionType() == null || !streamSourceInfo.isLeaveOpen()))
+                                    .doOnSuccess(ignored -> log.debug("Stream was ingested successfully."));
+                        })
+                        .onErrorMap(DataClientException.class, e -> {
+                            String msg = ExceptionUtils.getMessageEx(e);
+                            log.error(msg, e);
+                            return new IngestionClientException(msg, e);
+                        })
+                        .onErrorMap(DataServiceException.class, e -> {
+                            log.error(e.getMessage(), e);
+                            return new IngestionServiceException(e.getMessage(), e);
+                        })
+                        .map(ignore -> {
+                            log.debug("Stream was ingested successfully.");
+                            IngestionStatus ingestionStatus = new IngestionStatus();
+                            ingestionStatus.status = OperationStatus.Succeeded;
+                            ingestionStatus.table = ingestionProperties.getTableName();
+                            ingestionStatus.database = ingestionProperties.getDatabaseName();
+                            return new IngestionStatusResult(ingestionStatus);
+                        });
     }
 
-    private InputStream compressStream(InputStream uncompressedStream, boolean leaveOpen) throws IngestionClientException, IOException {
-        log.debug("Compressing the stream.");
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream);
-        byte[] b = new byte[STREAM_COMPRESS_BUFFER_SIZE];
-        int read = uncompressedStream.read(b);
-        if (read == -1) {
-            String message = "Empty stream.";
-            log.error(message);
-            throw new IngestionClientException(message);
-        }
-        do {
-            gzipOutputStream.write(b, 0, read);
-        } while ((read = uncompressedStream.read(b)) != -1);
-        gzipOutputStream.flush();
-        gzipOutputStream.close();
-        InputStream inputStream = new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
-        byteArrayOutputStream.close();
-        if (!leaveOpen) {
-            uncompressedStream.close();
-        }
-        return inputStream;
-    }
-
-    IngestionResult ingestFromBlob(BlobSourceInfo blobSourceInfo,
+    Mono<IngestionResult> ingestFromBlobAsync(BlobSourceInfo blobSourceInfo,
             IngestionProperties ingestionProperties,
-            BlobClient cloudBlockBlob,
-            @Nullable String clientRequestId)
-            throws IngestionClientException, IngestionServiceException {
-        // trace ingestFromBlob
-        return MonitoredActivity.invoke(
-                (SupplierTwoExceptions<IngestionResult, IngestionClientException, IngestionServiceException>) () -> ingestFromBlobImpl(blobSourceInfo,
+            BlobAsyncClient cloudBlockBlob,
+            @Nullable String clientRequestId) {
+        // trace ingestFromBlobAsync
+        return MonitoredActivity.wrap(
+                ingestFromBlobImplAsync(blobSourceInfo,
                         ingestionProperties, cloudBlockBlob, clientRequestId),
                 getClientType().concat(".ingestFromBlob"),
                 getIngestionTraceAttributes(blobSourceInfo, ingestionProperties));
     }
 
-    private IngestionResult ingestFromBlobImpl(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties, BlobClient cloudBlockBlob,
-            @Nullable String clientRequestId)
-            throws IngestionClientException, IngestionServiceException {
-        String blobPath = blobSourceInfo.getBlobPath();
-        try {
-            // No need to check blob size if it was given to us that it's not empty
-            if (blobSourceInfo.getRawSizeInBytes() == 0 && cloudBlockBlob.getProperties().getBlobSize() == 0) {
-                String message = "Empty blob.";
-                log.error(message);
-                throw new IngestionClientException(message);
-            }
-        } catch (BlobStorageException ex) {
-            throw new IngestionClientException(String.format("Exception trying to read blob metadata,%s",
-                    ex.getStatusCode() == 403 ? "this might mean the blob doesn't exist" : ""), ex);
-        }
-        ClientRequestProperties clientRequestProperties = null;
-        if (StringUtils.isNotBlank(clientRequestId)) {
-            clientRequestProperties = new ClientRequestProperties();
-            clientRequestProperties.setClientRequestId(clientRequestId);
-        }
-        IngestionProperties.DataFormat dataFormat = ingestionProperties.getDataFormat();
-        try {
-            this.streamingClient.executeStreamingIngestFromBlob(ingestionProperties.getDatabaseName(),
-                    ingestionProperties.getTableName(),
-                    blobPath,
-                    clientRequestProperties,
-                    dataFormat.getKustoValue(),
-                    ingestionProperties.getIngestionMapping().getIngestionMappingReference());
-        } catch (DataClientException e) {
-            log.error(e.getMessage(), e);
-            throw new IngestionClientException(e.getMessage(), e);
-        } catch (DataServiceException e) {
-            log.error(e.getMessage(), e);
-            throw new IngestionServiceException(e.getMessage(), e);
-        }
+    private Mono<IngestionResult> ingestFromBlobImplAsync(BlobSourceInfo blobSourceInfo, IngestionProperties ingestionProperties,
+            BlobAsyncClient cloudBlockBlob,
+            @Nullable String clientRequestId) {
 
-        log.debug("Blob was ingested successfully.");
-        IngestionStatus ingestionStatus = new IngestionStatus();
-        ingestionStatus.status = OperationStatus.Succeeded;
-        ingestionStatus.table = ingestionProperties.getTableName();
-        ingestionStatus.database = ingestionProperties.getDatabaseName();
-        return new IngestionStatusResult(ingestionStatus);
+        return cloudBlockBlob.getProperties()
+                .map(blobProperties -> {
+                    // No need to check blob size if it was given to us that it's not empty
+                    if (blobSourceInfo.getRawSizeInBytes() == 0 && blobProperties.getBlobSize() == 0) {
+                        String message = "Empty blob.";
+                        log.error(message);
+                        throw new IngestionClientException(message);
+                    }
+                    return true;
+                })
+                .onErrorMap(BlobStorageException.class, e -> new IngestionClientException(String.format("Exception trying to read blob metadata,%s",
+                        e.getStatusCode() == HttpStatus.FORBIDDEN ? "this might mean the blob doesn't exist" : ""), e))
+                .flatMap(ignore -> { // TODO: flatMaps
+                    String blobPath = blobSourceInfo.getBlobPath();
+                    ClientRequestProperties clientRequestProperties = null;
+                    if (StringUtils.isNotBlank(clientRequestId)) {
+                        clientRequestProperties = new ClientRequestProperties();
+                        clientRequestProperties.setClientRequestId(clientRequestId);
+                    }
+
+                    IngestionProperties.DataFormat dataFormat = ingestionProperties.getDataFormat();
+                    return this.streamingClient.executeStreamingIngestFromBlobAsync(ingestionProperties.getDatabaseName(),
+                            ingestionProperties.getTableName(),
+                            blobPath,
+                            clientRequestProperties,
+                            dataFormat.getKustoValue(),
+                            ingestionProperties.getIngestionMapping().getIngestionMappingReference());
+                })
+                .onErrorMap(DataClientException.class, e -> {
+                    log.error(e.getMessage(), e);
+                    return new IngestionClientException(e.getMessage(), e);
+                })
+                .onErrorMap(DataServiceException.class, e -> {
+                    log.error(e.getMessage(), e);
+                    return new IngestionServiceException(e.getMessage(), e);
+                })
+                .doOnSuccess(ignored1 -> log.debug("Blob was ingested successfully."))
+                .map(ignore -> {
+                    IngestionStatus ingestionStatus = new IngestionStatus();
+                    ingestionStatus.status = OperationStatus.Succeeded;
+                    ingestionStatus.table = ingestionProperties.getTableName();
+                    ingestionStatus.database = ingestionProperties.getDatabaseName();
+                    return new IngestionStatusResult(ingestionStatus);
+                });
+
     }
 
     protected void setConnectionDataSource(String connectionDataSource) {

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/exceptions/IngestionClientException.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/exceptions/IngestionClientException.java
@@ -5,8 +5,7 @@ package com.microsoft.azure.kusto.ingest.exceptions;
 
 import com.azure.core.exception.AzureException;
 
-public class IngestionClientException extends AzureException { // TODO: remove throws from internal method declarations (not from public Apis) on async ingest
-                                                               // impl
+public class IngestionClientException extends AzureException {
     private String ingestionSource;
 
     public String getIngestionSource() {

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/exceptions/IngestionServiceException.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/exceptions/IngestionServiceException.java
@@ -5,8 +5,7 @@ package com.microsoft.azure.kusto.ingest.exceptions;
 
 import com.azure.core.exception.AzureException;
 
-public class IngestionServiceException extends AzureException { // TODO: remove throws from internal method declarations (not from public Apis) on async ingest
-                                                                // impl
+public class IngestionServiceException extends AzureException {
     private String ingestionSource;
 
     public String getIngestionSource() {

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/resources/ContainerWithSas.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/resources/ContainerWithSas.java
@@ -1,15 +1,15 @@
 package com.microsoft.azure.kusto.ingest.resources;
 
 import com.azure.core.http.HttpClient;
-import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobContainerAsyncClient;
 import com.azure.storage.blob.BlobContainerClientBuilder;
 import com.microsoft.azure.kusto.data.UriUtils;
 
 import java.net.URISyntaxException;
 
-public class ContainerWithSas implements ResourceWithSas<BlobContainerClient> {
+public class ContainerWithSas implements ResourceWithSas<BlobContainerAsyncClient> {
     private final String sas;
-    private final BlobContainerClient container;
+    private final BlobContainerAsyncClient asyncContainer;
 
     public ContainerWithSas(String url, HttpClient httpClient) throws URISyntaxException {
         String[] parts = UriUtils.getSasAndEndpointFromResourceURL(url);
@@ -17,33 +17,33 @@ public class ContainerWithSas implements ResourceWithSas<BlobContainerClient> {
         String sas = parts[1];
         this.sas = '?' + sas;
 
-        this.container = new BlobContainerClientBuilder()
+        this.asyncContainer = new BlobContainerClientBuilder()
                 .endpoint(endpoint)
                 .sasToken(sas)
                 .httpClient(httpClient)
-                .buildClient();
+                .buildAsyncClient();
     }
 
     public String getSas() {
         return sas;
     }
 
-    public BlobContainerClient getContainer() {
-        return container;
+    public BlobContainerAsyncClient getAsyncContainer() {
+        return asyncContainer;
     }
 
     @Override
     public String getEndpointWithoutSas() {
-        return container.getBlobContainerUrl();
+        return asyncContainer.getBlobContainerUrl();
     }
 
     @Override
     public String getAccountName() {
-        return container.getAccountName();
+        return asyncContainer.getAccountName();
     }
 
     @Override
-    public BlobContainerClient getResource() {
-        return container;
+    public BlobContainerAsyncClient getResource() {
+        return asyncContainer;
     }
 }

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/resources/QueueWithSas.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/resources/QueueWithSas.java
@@ -2,53 +2,52 @@ package com.microsoft.azure.kusto.ingest.resources;
 
 import com.azure.core.http.HttpClient;
 import com.azure.storage.common.policy.RequestRetryOptions;
-import com.azure.storage.queue.QueueClient;
+import com.azure.storage.queue.QueueAsyncClient;
 import com.azure.storage.queue.QueueClientBuilder;
-import com.azure.storage.queue.implementation.AzureQueueStorageImpl;
 import com.microsoft.azure.kusto.data.UriUtils;
 import reactor.util.annotation.Nullable;
 
 import java.net.URISyntaxException;
 
-public class QueueWithSas implements ResourceWithSas<QueueClient> {
+public class QueueWithSas implements ResourceWithSas<QueueAsyncClient> {
     private final String sas;
-    private final QueueClient queue;
+    private final QueueAsyncClient queueAsyncClient;
 
     public QueueWithSas(String url, HttpClient httpClient, @Nullable RequestRetryOptions retryOptions) throws URISyntaxException {
         String[] parts = UriUtils.getSasAndEndpointFromResourceURL(url);
         this.sas = '?' + parts[1];
-        this.queue = new QueueClientBuilder()
+        this.queueAsyncClient = new QueueClientBuilder()
                 .endpoint(parts[0])
                 .sasToken(parts[1])
                 .httpClient(httpClient)
                 .retryOptions(retryOptions)
-                .buildClient();
+                .buildAsyncClient();
     }
 
     public String getSas() {
         return sas;
     }
 
-    public QueueClient getQueue() {
-        return queue;
+    public QueueAsyncClient getAsyncQueue() {
+        return queueAsyncClient;
     }
 
     public String getEndpoint() {
-        return queue.getQueueUrl() + sas;
+        return queueAsyncClient.getQueueUrl() + sas;
     }
 
     @Override
     public String getEndpointWithoutSas() {
-        return queue.getQueueUrl();
+        return queueAsyncClient.getQueueUrl();
     }
 
     @Override
     public String getAccountName() {
-        return queue.getAccountName();
+        return queueAsyncClient.getAccountName();
     }
 
     @Override
-    public QueueClient getResource() {
-        return queue;
+    public QueueAsyncClient getResource() {
+        return queueAsyncClient;
     }
 }

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionResult.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionResult.java
@@ -4,17 +4,19 @@
 package com.microsoft.azure.kusto.ingest.result;
 
 import com.azure.data.tables.implementation.models.TableServiceErrorException;
+import reactor.core.publisher.Mono;
 
 import java.io.Serializable;
 import java.net.URISyntaxException;
 import java.util.List;
 
 public interface IngestionResult extends Serializable {
-    /// <summary>
-    /// Retrieves the detailed ingestion status of
-    /// all data ingestion operations into Kusto associated with this com.microsoft.azure.kusto.ingest.IKustoIngestionResult instance.
-    /// </summary>
-    List<IngestionStatus> getIngestionStatusCollection() throws URISyntaxException, TableServiceErrorException;
+
+    /**
+     * Retrieves the detailed ingestion status of
+     * all data ingestion operations into Kusto associated with this com.microsoft.azure.kusto.ingest.IKustoIngestionResult instance.
+     */
+    Mono<List<IngestionStatus>> getIngestionStatusCollection() throws URISyntaxException, TableServiceErrorException;
 
     int getIngestionStatusesLength();
 }

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionStatusInTableDescription.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionStatusInTableDescription.java
@@ -3,12 +3,13 @@
 
 package com.microsoft.azure.kusto.ingest.result;
 
-import com.azure.data.tables.TableClient;
+import com.azure.data.tables.TableAsyncClient;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.microsoft.azure.kusto.ingest.utils.TableWithSas;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.util.annotation.Nullable;
 
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
@@ -26,7 +27,7 @@ public class IngestionStatusInTableDescription implements Serializable {
     private String rowKey;
 
     @JsonIgnore
-    private transient TableClient tableClient;
+    private transient TableAsyncClient tableAsyncClient;
 
     public String getTableConnectionString() {
         return this.tableConnectionString;
@@ -52,20 +53,21 @@ public class IngestionStatusInTableDescription implements Serializable {
         this.rowKey = rowKey;
     }
 
-    public TableClient getTableClient() {
-        if (tableClient == null) {
+    @Nullable
+    public TableAsyncClient getTableAsyncClient() {
+        if (tableAsyncClient == null) {
             try {
-                tableClient = TableWithSas.TableClientFromUrl(getTableConnectionString(), null);
+                tableAsyncClient = TableWithSas.createTableClientFromUrl(getTableConnectionString(), null);
             } catch (URISyntaxException uriSyntaxException) {
                 log.error("TableConnectionString could not be parsed as URI reference.", uriSyntaxException);
                 return null;
             }
         }
 
-        return tableClient;
+        return tableAsyncClient;
     }
 
-    public void setTableClient(TableClient tableClient) {
-        this.tableClient = tableClient;
+    public void setAsyncTableClient(TableAsyncClient tableAsyncClient) {
+        this.tableAsyncClient = tableAsyncClient;
     }
 }

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionStatusResult.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionStatusResult.java
@@ -3,6 +3,8 @@
 
 package com.microsoft.azure.kusto.ingest.result;
 
+import reactor.core.publisher.Mono;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -15,8 +17,13 @@ public class IngestionStatusResult implements IngestionResult {
     }
 
     @Override
-    public List<IngestionStatus> getIngestionStatusCollection() {
-        return Collections.singletonList(this.ingestionStatus);
+    public Mono<List<IngestionStatus>> getIngestionStatusCollection() {
+        return Mono.defer(() -> {
+            if (ingestionStatus != null) {
+                return Mono.just(Collections.singletonList(ingestionStatus));
+            }
+            return Mono.empty();
+        });
     }
 
     @Override

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/TableReportIngestionResult.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/TableReportIngestionResult.java
@@ -3,12 +3,13 @@
 
 package com.microsoft.azure.kusto.ingest.result;
 
-import com.azure.data.tables.TableClient;
+import com.azure.data.tables.TableAsyncClient;
 import com.azure.data.tables.implementation.models.TableServiceErrorException;
-import com.azure.data.tables.models.TableEntity;
+import reactor.core.publisher.Mono;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class TableReportIngestionResult implements IngestionResult {
     private final List<IngestionStatusInTableDescription> descriptors;
@@ -18,15 +19,26 @@ public class TableReportIngestionResult implements IngestionResult {
     }
 
     @Override
-    public List<IngestionStatus> getIngestionStatusCollection() throws TableServiceErrorException {
-        List<IngestionStatus> results = new LinkedList<>();
-        for (IngestionStatusInTableDescription descriptor : descriptors) {
-            TableClient table = descriptor.getTableClient();
-            TableEntity entity = table.getEntity(descriptor.getPartitionKey(), descriptor.getRowKey());
-            results.add(IngestionStatus.fromEntity(entity));
-        }
+    public Mono<List<IngestionStatus>> getIngestionStatusCollection() throws TableServiceErrorException {
+        List<Mono<IngestionStatus>> ingestionStatusMonos = descriptors.stream()
+                .map(descriptor -> {
+                    TableAsyncClient tableAsyncClient = descriptor.getTableAsyncClient();
+                    if (tableAsyncClient != null) {
+                        return tableAsyncClient.getEntity(descriptor.getPartitionKey(), descriptor.getRowKey())
+                                .map(IngestionStatus::fromEntity);
+                    } else {
+                        return Mono.<IngestionStatus>empty();
+                    }
+                })
+                .collect(Collectors.toList());
 
-        return results;
+        return Mono.zip(ingestionStatusMonos, results -> {
+            List<IngestionStatus> resultList = new LinkedList<>();
+            for (Object result : results) {
+                resultList.add((IngestionStatus) result);
+            }
+            return resultList;
+        });
     }
 
     @Override

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/source/ResultSetSourceInfo.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/source/ResultSetSourceInfo.java
@@ -3,9 +3,6 @@
 
 package com.microsoft.azure.kusto.ingest.source;
 
-import com.microsoft.azure.kusto.data.instrumentation.TraceableAttributes;
-import org.jetbrains.annotations.NotNull;
-
 import java.sql.ResultSet;
 import java.util.Map;
 import java.util.Objects;

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/utils/TableWithSas.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/utils/TableWithSas.java
@@ -1,7 +1,7 @@
 package com.microsoft.azure.kusto.ingest.utils;
 
 import com.azure.core.http.HttpClient;
-import com.azure.data.tables.TableClient;
+import com.azure.data.tables.TableAsyncClient;
 import com.azure.data.tables.TableClientBuilder;
 import com.microsoft.azure.kusto.data.UriUtils;
 import reactor.util.annotation.Nullable;
@@ -10,22 +10,22 @@ import java.net.URISyntaxException;
 
 public class TableWithSas {
     private final String uri;
-    private final TableClient table;
+    private final TableAsyncClient tableAsyncClient;
 
     public TableWithSas(String url, @Nullable HttpClient httpClient) throws URISyntaxException {
         this.uri = url;
-        this.table = TableClientFromUrl(url, httpClient);
+        this.tableAsyncClient = createTableClientFromUrl(url, httpClient);
     }
 
     public String getUri() {
         return uri;
     }
 
-    public TableClient getTable() {
-        return table;
+    public TableAsyncClient getTableAsyncClient() {
+        return tableAsyncClient;
     }
 
-    public static TableClient TableClientFromUrl(String url, @Nullable HttpClient httpClient) throws URISyntaxException {
+    public static TableAsyncClient createTableClientFromUrl(String url, @Nullable HttpClient httpClient) throws URISyntaxException {
         String[] parts = UriUtils.getSasAndEndpointFromResourceURL(url);
         int tableNameIndex = parts[0].lastIndexOf('/');
         String tableName = parts[0].substring(tableNameIndex + 1);
@@ -34,6 +34,6 @@ public class TableWithSas {
                 .sasToken(parts[1])
                 .tableName(tableName)
                 .httpClient(httpClient)
-                .buildClient();
+                .buildAsyncClient();
     }
 }

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
@@ -780,10 +780,10 @@ class E2ETest {
                         UUID.randomUUID(),
                         item.ingestionProperties.getDataFormat());
 
-                String blobPath = container.getContainer().getBlobContainerUrl() + "/" + blobName + container.getSas();
+                String blobPath = container.getAsyncContainer().getBlobContainerUrl() + "/" + blobName + container.getSas();
 
                 azureStorageClient.uploadLocalFileToBlob(item.file, blobName,
-                        container.getContainer(), !item.file.getName().endsWith(".gz"));
+                        container.getAsyncContainer(), !item.file.getName().endsWith(".gz"));
                 try {
                     streamingIngestClient.ingestFromBlob(new BlobSourceInfo(blobPath), item.ingestionProperties);
                 } catch (Exception ex) {

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ManagedStreamingTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/ManagedStreamingTest.java
@@ -2,6 +2,7 @@ package com.microsoft.azure.kusto.ingest;
 
 import com.azure.data.tables.models.TableEntity;
 import com.microsoft.azure.kusto.data.ExponentialRetry;
+import com.microsoft.azure.kusto.data.KustoOperationResult;
 import com.microsoft.azure.kusto.data.StreamingClient;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionClientException;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException;
@@ -13,19 +14,25 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Mono;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ManagedStreamingTest {
     private static final ResourceManager resourceManagerMock = mock(ResourceManager.class);
@@ -34,11 +41,13 @@ public class ManagedStreamingTest {
     private static QueuedIngestClient queuedIngestClientMock;
     private static IngestionProperties ingestionProperties;
     private static StreamingClient streamingClientMock;
+    private static KustoOperationResult kustoOperationResultMock;
     private static ManagedStreamingIngestClient managedStreamingIngestClient;
     private static ManagedStreamingIngestClient managedStreamingIngestClientSpy;
 
     @BeforeAll
-    static void setUp() throws Exception {
+    static void setUp() {
+        kustoOperationResultMock = mock(KustoOperationResult.class);
         when(resourceManagerMock.getShuffledContainers())
                 .thenReturn(Collections.singletonList(TestUtils.containerWithSasFromAccountNameAndContainerName(ACCOUNT_NAME, "someStorage")));
         when(resourceManagerMock.getShuffledQueues())
@@ -49,12 +58,13 @@ public class ManagedStreamingTest {
 
         when(resourceManagerMock.getIdentityToken()).thenReturn("identityToken");
 
-        doNothing().when(azureStorageClientMock).azureTableInsertEntity(any(), any(TableEntity.class));
+        when(azureStorageClientMock.azureTableInsertEntity(any(), any(TableEntity.class))).thenReturn(Mono.empty());
 
-        doNothing().when(azureStorageClientMock).postMessageToQueue(any(), anyString());
+        when(azureStorageClientMock.postMessageToQueue(any(), anyString())).thenReturn(Mono.empty());
+        when(azureStorageClientMock.uploadStreamToBlob(any(), any(), any(), anyBoolean())).thenReturn(Mono.empty());
         streamingClientMock = mock(StreamingClient.class);
-        when(streamingClientMock.executeStreamingIngest(any(String.class), any(String.class), any(InputStream.class),
-                isNull(), any(String.class), any(String.class), any(boolean.class))).thenReturn(null);
+        when(streamingClientMock.executeStreamingIngestAsync(any(), any(), any(),
+                any(), any(), any(), any(boolean.class))).thenReturn(Mono.just(kustoOperationResultMock));
 
         ingestionProperties = new IngestionProperties("dbName", "tableName");
         managedStreamingIngestClient = new ManagedStreamingIngestClient(resourceManagerMock, azureStorageClientMock,
@@ -83,21 +93,21 @@ public class ManagedStreamingTest {
     }
 
     @Test
-    void IngestFromStream_CsvStream() throws Exception {
+    void ingestFromStream_CsvStream() throws Exception {
 
         InputStream inputStream = createStreamOfSize(1);
         StreamSourceInfo streamSourceInfo = new StreamSourceInfo(inputStream);
 
         // Expect to work and also choose no queuing
         OperationStatus status = managedStreamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection()
-                .get(0).status;
+                .block().get(0).status;
         assertEquals(OperationStatus.Succeeded, status);
 
         BooleanConsumer assertPolicyWorked = (boolean wasExpectedToUseQueuing) -> {
             try {
                 inputStream.reset();
                 IngestionStatus ingestionStatus = managedStreamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties)
-                        .getIngestionStatusCollection().get(0);
+                        .getIngestionStatusCollection().block().get(0);
                 if (wasExpectedToUseQueuing) {
                     assertEquals(OperationStatus.Queued, ingestionStatus.status);
                 } else {
@@ -169,9 +179,9 @@ public class ManagedStreamingTest {
         int size = inputStream.bb.available();
         StreamSourceInfo streamSourceInfo = new StreamSourceInfo(inputStream);
         ArgumentCaptor<StreamSourceInfo> streamSourceInfoCaptor = ArgumentCaptor.forClass(StreamSourceInfo.class);
-
+        when(queuedIngestClientMock.ingestFromStreamAsync(any(), any())).thenReturn(Mono.empty());
         managedStreamingIngestClientSpy.ingestFromStream(streamSourceInfo, ingestionProperties);
-        verify(queuedIngestClientMock, times(1)).ingestFromStream(streamSourceInfoCaptor.capture(), any());
+        verify(queuedIngestClientMock).ingestFromStreamAsync(streamSourceInfoCaptor.capture(), any());
 
         StreamSourceInfo value = streamSourceInfoCaptor.getValue();
         int queuedStreamSize = getStreamSize(value.getStream());

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/StreamingIngestClientTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/StreamingIngestClientTest.java
@@ -3,10 +3,11 @@
 
 package com.microsoft.azure.kusto.ingest;
 
-import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobAsyncClient;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.specialized.BlobInputStream;
 import com.microsoft.azure.kusto.data.ClientRequestProperties;
+import com.microsoft.azure.kusto.data.KustoOperationResult;
 import com.microsoft.azure.kusto.data.StreamingClient;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
 import com.microsoft.azure.kusto.data.exceptions.DataClientException;
@@ -15,7 +16,11 @@ import com.microsoft.azure.kusto.ingest.exceptions.IngestionClientException;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException;
 import com.microsoft.azure.kusto.ingest.result.IngestionResult;
 import com.microsoft.azure.kusto.ingest.result.OperationStatus;
-import com.microsoft.azure.kusto.ingest.source.*;
+import com.microsoft.azure.kusto.ingest.source.BlobSourceInfo;
+import com.microsoft.azure.kusto.ingest.source.CompressionType;
+import com.microsoft.azure.kusto.ingest.source.FileSourceInfo;
+import com.microsoft.azure.kusto.ingest.source.ResultSetSourceInfo;
+import com.microsoft.azure.kusto.ingest.source.StreamSourceInfo;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +31,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -41,8 +48,15 @@ import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class StreamingIngestClientTest {
     private static StreamingIngestClient streamingIngestClient;
@@ -54,6 +68,8 @@ class StreamingIngestClientTest {
     @Captor
     private static ArgumentCaptor<InputStream> argumentCaptor;
 
+    private static KustoOperationResult kustoOperationResult;
+
     private final String resourcesDirectory = System.getProperty("user.dir") + "/src/test/resources/";
 
     @BeforeAll
@@ -61,16 +77,15 @@ class StreamingIngestClientTest {
         streamingClientMock = mock(StreamingClient.class);
         streamingIngestClient = new StreamingIngestClient(streamingClientMock);
         argumentCaptor = ArgumentCaptor.forClass((InputStream.class));
+        kustoOperationResult = mock(KustoOperationResult.class);
     }
 
     @BeforeEach
     void setUpEach() throws Exception {
         ingestionProperties = new IngestionProperties("dbName", "tableName");
-        when(streamingClientMock.executeStreamingIngest(any(String.class), any(String.class), any(InputStream.class),
-                isNull(), any(String.class), any(String.class), any(boolean.class))).thenReturn(null);
-
-        when(streamingClientMock.executeStreamingIngest(any(String.class), any(String.class), any(InputStream.class),
-                isNull(), any(String.class), isNull(), any(boolean.class))).thenReturn(null);
+        when(streamingClientMock.executeStreamingIngestAsync(any(), any(), any(), any(), any(), any(), any(boolean.class)))
+                .thenReturn(Mono.just(kustoOperationResult));
+        when(streamingClientMock.executeStreamingIngestFromBlobAsync(any(), any(), any(), any(), any(), any())).thenReturn(Mono.just(kustoOperationResult));
     }
 
     @Test
@@ -78,9 +93,10 @@ class StreamingIngestClientTest {
         String data = "Name, Age, Weight, Height";
         InputStream inputStream = new ByteArrayInputStream(StandardCharsets.UTF_8.encode(data).array());
         StreamSourceInfo streamSourceInfo = new StreamSourceInfo(inputStream);
-        OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+        OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().block()
+                .get(0).status;
         assertEquals(OperationStatus.Succeeded, status);
-        verify(streamingClientMock, atLeastOnce()).executeStreamingIngest(any(String.class), any(String.class), argumentCaptor.capture(),
+        verify(streamingClientMock, atLeastOnce()).executeStreamingIngestAsync(any(String.class), any(String.class), argumentCaptor.capture(),
                 isNull(), any(String.class), isNull(), any(boolean.class));
 
         /*
@@ -98,11 +114,15 @@ class StreamingIngestClientTest {
         InputStream inputStream = new ByteArrayInputStream(StandardCharsets.UTF_8.encode(data).array());
         StreamSourceInfo streamSourceInfo = new StreamSourceInfo(inputStream);
         String clientRequestId = "clientRequestId";
-        OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties, clientRequestId).getIngestionStatusCollection()
-                .get(0).status;
+
+        IngestionResult ingestionResult = streamingIngestClient.ingestFromStreamAsync(streamSourceInfo, ingestionProperties, clientRequestId).block();
+        assertNotNull(ingestionResult);
+
+        OperationStatus status = ingestionResult.getIngestionStatusCollection()
+                .block().get(0).status;
         assertEquals(OperationStatus.Succeeded, status);
         ArgumentCaptor<ClientRequestProperties> clientRequestPropertiesArgumentCaptor = ArgumentCaptor.forClass(ClientRequestProperties.class);
-        verify(streamingClientMock, atLeastOnce()).executeStreamingIngest(any(String.class), any(String.class), argumentCaptor.capture(),
+        verify(streamingClientMock, atLeastOnce()).executeStreamingIngestAsync(any(String.class), any(String.class), argumentCaptor.capture(),
                 clientRequestPropertiesArgumentCaptor.capture(), any(String.class), isNull(), any(boolean.class));
 
         /*
@@ -129,9 +149,10 @@ class StreamingIngestClientTest {
         StreamSourceInfo streamSourceInfo = new StreamSourceInfo(inputStream);
         // When ingesting compressed data, we should set this property true to avoid double compression.
         streamSourceInfo.setCompressionType(CompressionType.gz);
-        OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+        OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().block()
+                .get(0).status;
         assertEquals(OperationStatus.Succeeded, status);
-        verify(streamingClientMock, atLeastOnce()).executeStreamingIngest(any(String.class), any(String.class), argumentCaptor.capture(),
+        verify(streamingClientMock, atLeastOnce()).executeStreamingIngestAsync(any(String.class), any(String.class), argumentCaptor.capture(),
                 isNull(), any(String.class), isNull(), any(boolean.class));
 
         InputStream stream = argumentCaptor.getValue();
@@ -145,9 +166,10 @@ class StreamingIngestClientTest {
         StreamSourceInfo streamSourceInfo = new StreamSourceInfo(inputStream);
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.JSON);
         ingestionProperties.setIngestionMapping("JsonMapping", IngestionMapping.IngestionMappingKind.JSON);
-        OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+        OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().block()
+                .get(0).status;
         assertEquals(OperationStatus.Succeeded, status);
-        verify(streamingClientMock, atLeastOnce()).executeStreamingIngest(any(String.class), any(String.class), argumentCaptor.capture(),
+        verify(streamingClientMock, atLeastOnce()).executeStreamingIngestAsync(any(String.class), any(String.class), argumentCaptor.capture(),
                 isNull(), any(String.class), any(String.class), any(boolean.class));
 
         InputStream stream = argumentCaptor.getValue();
@@ -168,9 +190,10 @@ class StreamingIngestClientTest {
         streamSourceInfo.setCompressionType(CompressionType.gz);
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.JSON);
         ingestionProperties.setIngestionMapping("JsonMapping", IngestionMapping.IngestionMappingKind.JSON);
-        OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+        OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().block()
+                .get(0).status;
         assertEquals(OperationStatus.Succeeded, status);
-        verify(streamingClientMock, atLeastOnce()).executeStreamingIngest(any(String.class), any(String.class), argumentCaptor.capture(),
+        verify(streamingClientMock, atLeastOnce()).executeStreamingIngestAsync(any(String.class), any(String.class), argumentCaptor.capture(),
                 isNull(), any(String.class), any(String.class), any(boolean.class));
 
         InputStream stream = argumentCaptor.getValue();
@@ -215,21 +238,21 @@ class StreamingIngestClientTest {
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.JSON);
         ingestionProperties.setIngestionMapping("JsonMapping", IngestionMapping.IngestionMappingKind.JSON);
         IngestionResult ingestionResult = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties);
-        assertEquals("Succeeded", ingestionResult.getIngestionStatusCollection().get(0).status.name());
+        assertEquals("Succeeded", ingestionResult.getIngestionStatusCollection().block().get(0).status.name());
         assertEquals(1, ingestionResult.getIngestionStatusesLength());
     }
 
     @Test
-    void ingestFromStream_JsonWrongMappingKind_IngestionClientException() {
+    void ingestFromStreamAsync_JsonWrongMappingKind_IngestionClientException() {
         String data = "{\"Name\": \"name\", \"Age\": \"age\", \"Weight\": \"weight\", \"Height\": \"height\"}";
         InputStream inputStream = new ByteArrayInputStream(StandardCharsets.UTF_8.encode(data).array());
         StreamSourceInfo streamSourceInfo = new StreamSourceInfo(inputStream);
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.JSON);
         ingestionProperties.setIngestionMapping("CsvMapping", IngestionMapping.IngestionMappingKind.CSV);
-        IngestionClientException ingestionClientException = assertThrows(IngestionClientException.class,
-                () -> streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties),
-                "Expected IngestionClientException to be thrown, but it didn't");
-        assertTrue(ingestionClientException.getMessage().contains("Wrong ingestion mapping for format 'json'; mapping kind should be 'Json', but was 'Csv'."));
+        StepVerifier.create(streamingIngestClient.ingestFromStreamAsync(streamSourceInfo, ingestionProperties))
+                .expectErrorMatches(e -> e instanceof IngestionClientException
+                        && e.getMessage().contains("Wrong ingestion mapping for format 'json'; mapping kind should be 'Json', but was 'Csv'."))
+                .verify();
     }
 
     @Test
@@ -240,65 +263,68 @@ class StreamingIngestClientTest {
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.AVRO);
         ingestionProperties.setIngestionMapping("AvroMapping", IngestionMapping.IngestionMappingKind.AVRO);
         IngestionResult ingestionResult = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties);
-        assertEquals("Succeeded", ingestionResult.getIngestionStatusCollection().get(0).status.name());
+        assertEquals("Succeeded", ingestionResult.getIngestionStatusCollection().block().get(0).status.name());
         assertEquals(1, ingestionResult.getIngestionStatusesLength());
     }
 
     @Test
-    void ingestFromStream_AvroWrongMappingKind_IngestionClientException() {
+    void ingestFromStreamAsync_AvroWrongMappingKind_IngestionClientException() {
         InputStream inputStream = new ByteArrayInputStream(new byte[10]);
         StreamSourceInfo streamSourceInfo = new StreamSourceInfo(inputStream);
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.AVRO);
         ingestionProperties.setIngestionMapping("CsvMapping", IngestionMapping.IngestionMappingKind.CSV);
-        IngestionClientException ingestionClientException = assertThrows(IngestionClientException.class,
-                () -> streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties),
-                "Expected IngestionClientException to be thrown, but it didn't");
-        assertTrue(ingestionClientException.getMessage().contains("Wrong ingestion mapping for format 'avro'; mapping kind should be 'Avro', but was 'Csv'."));
+        StepVerifier.create(streamingIngestClient.ingestFromStreamAsync(streamSourceInfo, ingestionProperties))
+                .expectErrorMatches(e -> e instanceof IngestionClientException
+                        && e.getMessage().contains("Wrong ingestion mapping for format 'avro'; mapping kind should be 'Avro', but was 'Csv'."))
+                .verify();
     }
 
     @Test
-    void ingestFromStream_EmptyStream_IngestionClientException() {
+    void ingestFromStreamAsync_EmptyStream_IngestionClientException() {
         InputStream inputStream = new ByteArrayInputStream(new byte[0]);
         StreamSourceInfo streamSourceInfo = new StreamSourceInfo(inputStream);
-        IngestionClientException ingestionClientException = assertThrows(IngestionClientException.class,
-                () -> streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties),
-                "Expected IngestionClientException to be thrown, but it didn't");
-        assertTrue(ingestionClientException.getMessage().contains("Empty stream."));
+        StepVerifier.create(streamingIngestClient.ingestFromStreamAsync(streamSourceInfo, ingestionProperties))
+                .expectErrorMatches(e -> e instanceof IngestionClientException && e.getMessage().contains("Empty stream."))
+                .verify();
     }
 
     @Test
-    void ingestFromStream_CaughtDataClientException_IngestionClientException() throws Exception {
-        when(streamingClientMock.executeStreamingIngest(any(String.class), any(String.class), any(InputStream.class),
-                isNull(), any(String.class), isNull(), any(boolean.class))).thenThrow(DataClientException.class);
+    void ingestFromStreamAsync_CaughtDataClientException_IngestionClientException() {
+        when(streamingClientMock.executeStreamingIngestAsync(any(String.class), any(String.class), any(InputStream.class),
+                isNull(), any(String.class), isNull(), any(boolean.class))).thenReturn(Mono.error(new DataClientException("DataClientException")));
 
         String data = "Name, Age, Weight, Height";
         InputStream inputStream = new ByteArrayInputStream(StandardCharsets.UTF_8.encode(data).array());
         StreamSourceInfo streamSourceInfo = new StreamSourceInfo(inputStream);
-        assertThrows(IngestionClientException.class,
-                () -> streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties),
-                "Expected IllegalArgumentException to be thrown, but it didn't");
+        StepVerifier.create(streamingIngestClient.ingestFromStreamAsync(streamSourceInfo, ingestionProperties))
+                .expectErrorMatches(e -> e instanceof IngestionClientException
+                        && "DataClientException".equals(e.getMessage()))
+                .verify();
     }
 
     @Test
-    void ingestFromStream_CaughtDataServiceException_IngestionServiceException() throws Exception {
-        when(streamingClientMock.executeStreamingIngest(any(String.class), any(String.class), any(InputStream.class),
-                isNull(), any(String.class), isNull(), any(boolean.class))).thenThrow(DataServiceException.class);
+    void ingestFromStream_CaughtDataServiceException_IngestionServiceException() {
+        when(streamingClientMock.executeStreamingIngestAsync(any(String.class), any(String.class), any(InputStream.class),
+                isNull(), any(String.class), isNull(), any(boolean.class)))
+                        .thenReturn(Mono.error(new DataServiceException("ingestFromStream", "DataServiceException", true)));
 
         String data = "Name, Age, Weight, Height";
         InputStream inputStream = new ByteArrayInputStream(StandardCharsets.UTF_8.encode(data).array());
         StreamSourceInfo streamSourceInfo = new StreamSourceInfo(inputStream);
-        assertThrows(IngestionServiceException.class,
-                () -> streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties),
-                "Expected IllegalArgumentException to be thrown, but it didn't");
+        StepVerifier.create(streamingIngestClient.ingestFromStreamAsync(streamSourceInfo, ingestionProperties))
+                .expectErrorMatches(e -> e instanceof IngestionServiceException
+                        && "DataServiceException".equals(e.getMessage()))
+                .verify();
     }
 
     @Test
     void ingestFromFile_Csv() throws Exception {
         String path = resourcesDirectory + "testdata.csv";
         FileSourceInfo fileSourceInfo = new FileSourceInfo(path, new File(path).length());
-        OperationStatus status = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+        OperationStatus status = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties).getIngestionStatusCollection().block()
+                .get(0).status;
         assertEquals(OperationStatus.Succeeded, status);
-        verify(streamingClientMock, atLeastOnce()).executeStreamingIngest(any(String.class), any(String.class), any(InputStream.class),
+        verify(streamingClientMock, atLeastOnce()).executeStreamingIngestAsync(any(String.class), any(String.class), any(InputStream.class),
                 isNull(), any(String.class), isNull(), any(boolean.class));
     }
 
@@ -310,9 +336,10 @@ class StreamingIngestClientTest {
 
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.JSON);
         ingestionProperties.setIngestionMapping("JsonMapping", IngestionMapping.IngestionMappingKind.JSON);
-        OperationStatus status = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+        OperationStatus status = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties).getIngestionStatusCollection().block()
+                .get(0).status;
         assertEquals(OperationStatus.Succeeded, status);
-        verify(streamingClientMock, atLeastOnce()).executeStreamingIngest(any(String.class), any(String.class), argumentCaptor.capture(),
+        verify(streamingClientMock, atLeastOnce()).executeStreamingIngestAsync(any(String.class), any(String.class), argumentCaptor.capture(),
                 isNull(), any(String.class), any(String.class), any(boolean.class));
 
         verifyCompressedStreamContent(argumentCaptor.getValue(), contents);
@@ -324,9 +351,10 @@ class StreamingIngestClientTest {
         FileSourceInfo fileSourceInfo = new FileSourceInfo(path, new File(path).length());
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.JSON);
         ingestionProperties.setIngestionMapping("JsonMapping", IngestionMapping.IngestionMappingKind.JSON);
-        OperationStatus status = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+        OperationStatus status = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties).getIngestionStatusCollection().block()
+                .get(0).status;
         assertEquals(OperationStatus.Succeeded, status);
-        verify(streamingClientMock, atLeastOnce()).executeStreamingIngest(any(String.class), any(String.class), argumentCaptor.capture(),
+        verify(streamingClientMock, atLeastOnce()).executeStreamingIngestAsync(any(String.class), any(String.class), argumentCaptor.capture(),
                 isNull(), any(String.class), any(String.class), any(boolean.class));
 
         verifyCompressedStreamContent(argumentCaptor.getValue(), jsonDataUncompressed);
@@ -383,20 +411,20 @@ class StreamingIngestClientTest {
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.JSON);
         ingestionProperties.setIngestionMapping("JsonMapping", IngestionMapping.IngestionMappingKind.JSON);
         IngestionResult ingestionResult = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties);
-        assertEquals("Succeeded", ingestionResult.getIngestionStatusCollection().get(0).status.name());
+        assertEquals("Succeeded", ingestionResult.getIngestionStatusCollection().block().get(0).status.name());
         assertEquals(1, ingestionResult.getIngestionStatusesLength());
     }
 
     @Test
-    void ingestFromFile_JsonWrongMappingKind_IngestionClientException() {
+    void ingestFromFileAsync_JsonWrongMappingKind_IngestionClientException() {
         String path = resourcesDirectory + "testdata.json";
         FileSourceInfo fileSourceInfo = new FileSourceInfo(path, new File(path).length());
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.JSON);
         ingestionProperties.setIngestionMapping("CsvMapping", IngestionMapping.IngestionMappingKind.CSV);
-        IngestionClientException ingestionClientException = assertThrows(IngestionClientException.class,
-                () -> streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties),
-                "Expected IngestionClientException to be thrown, but it didn't");
-        assertTrue(ingestionClientException.getMessage().contains("Wrong ingestion mapping for format 'json'; mapping kind should be 'Json', but was 'Csv'."));
+        StepVerifier.create(streamingIngestClient.ingestFromFileAsync(fileSourceInfo, ingestionProperties))
+                .expectErrorMatches(e -> e instanceof IngestionClientException
+                        && e.getMessage().contains("Wrong ingestion mapping for format 'json'; mapping kind should be 'Json', but was 'Csv'."))
+                .verify();
     }
 
     @Test
@@ -404,23 +432,23 @@ class StreamingIngestClientTest {
         String path = resourcesDirectory + "testdata.json";
         FileSourceInfo fileSourceInfo = new FileSourceInfo(path, new File(path).length());
         IngestionResult ingestionResult = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties);
-        assertEquals("Succeeded", ingestionResult.getIngestionStatusCollection().get(0).status.name());
+        assertEquals("Succeeded", ingestionResult.getIngestionStatusCollection().block().get(0).status.name());
         assertEquals(1, ingestionResult.getIngestionStatusesLength());
     }
 
     @Test
-    void ingestFromFile_EmptyFile_IngestionClientException() {
+    void ingestFromFileAsync_EmptyFile_IngestionClientException() {
         String path = resourcesDirectory + "empty.csv";
         FileSourceInfo fileSourceInfo = new FileSourceInfo(path, new File(path).length());
-        IngestionClientException ingestionClientException = assertThrows(IngestionClientException.class,
-                () -> streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties),
-                "Expected IngestionClientException to be thrown, but it didn't");
-        assertTrue(ingestionClientException.getMessage().contains("Empty file."));
+        StepVerifier.create(streamingIngestClient.ingestFromFileAsync(fileSourceInfo, ingestionProperties))
+                .expectErrorMatches(e -> e instanceof IngestionClientException && e.getMessage().contains("Empty file."))
+                .verify();
     }
 
     @Test
     void ingestFromBlob() throws Exception {
-        BlobClient cloudBlockBlob = mock(BlobClient.class);
+        BlobAsyncClient cloudBlockBlob = mock(BlobAsyncClient.class);
+        // BlobClient cloudBlockBlob = mock(BlobAsyncClient.class);
         String blobPath = "https://kustotest.blob.core.windows.net/container/blob.csv";
         BlobSourceInfo blobSourceInfo = new BlobSourceInfo(blobPath);
         BlobProperties blobProperties = mock(BlobProperties.class);
@@ -429,96 +457,94 @@ class StreamingIngestClientTest {
         BlobInputStream blobInputStream = mock(BlobInputStream.class);
         when(blobInputStream.read(any(byte[].class))).thenReturn(10).thenReturn(-1);
 
-        when(cloudBlockBlob.getProperties()).thenReturn(blobProperties);
-        when(cloudBlockBlob.openInputStream()).thenReturn(blobInputStream);
+        when(cloudBlockBlob.getProperties()).thenReturn(Mono.just(blobProperties));
+        // when(cloudBlockBlob.strea()).thenReturn(blobInputStream);
 
-        OperationStatus status = streamingIngestClient.ingestFromBlob(blobSourceInfo, ingestionProperties, cloudBlockBlob, null).getIngestionStatusCollection()
-                .get(0).status;
+        OperationStatus status = streamingIngestClient.ingestFromBlobAsync(blobSourceInfo, ingestionProperties, cloudBlockBlob, null).block()
+                .getIngestionStatusCollection()
+                .block().get(0).status;
         assertEquals(OperationStatus.Succeeded, status);
-        verify(streamingClientMock, atLeastOnce()).executeStreamingIngest(any(String.class), any(String.class), any(InputStream.class),
-                isNull(), any(String.class), isNull(), any(boolean.class));
+        verify(streamingClientMock, atLeastOnce()).executeStreamingIngestFromBlobAsync(any(String.class), any(String.class), any(String.class),
+                isNull(), any(String.class), any());
     }
 
     @Test
-    void ingestFromBlob_NullBlobSourceInfo_IllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class,
-                () -> streamingIngestClient.ingestFromBlob(null, ingestionProperties),
-                "Expected IllegalArgumentException to be thrown, but it didn't");
+    void ingestFromBlobAsync_NullBlobSourceInfo_IllegalArgumentException() {
+        StepVerifier.create(streamingIngestClient.ingestFromBlobAsync(null, ingestionProperties))
+                .expectError(IllegalArgumentException.class)
+                .verify();
     }
 
     @Test
-    void ingestFromBlob_BlobSourceInfoWithNullBlobPath_IllegalArgumentException() {
+    void ingestFromBlobAsync_BlobSourceInfoWithNullBlobPath_IllegalArgumentException() {
         BlobSourceInfo blobSourceInfo1 = new BlobSourceInfo(null);
-        assertThrows(IllegalArgumentException.class,
-                () -> streamingIngestClient.ingestFromBlob(blobSourceInfo1, ingestionProperties),
-                "Expected IllegalArgumentException to be thrown, but it didn't");
+        StepVerifier.create(streamingIngestClient.ingestFromBlobAsync(blobSourceInfo1, ingestionProperties))
+                .expectError(IllegalArgumentException.class)
+                .verify();
     }
 
     @Test
-    void ingestFromBlob_BlobSourceInfoWithBlankBlobPath_IllegalArgumentException() {
+    void ingestFromBlobAsync_BlobSourceInfoWithBlankBlobPath_IllegalArgumentException() {
         BlobSourceInfo blobSourceInfo2 = new BlobSourceInfo("");
-        assertThrows(IllegalArgumentException.class,
-                () -> streamingIngestClient.ingestFromBlob(blobSourceInfo2, ingestionProperties),
-                "Expected IllegalArgumentException to be thrown, but it didn't");
+        StepVerifier.create(streamingIngestClient.ingestFromBlobAsync(blobSourceInfo2, ingestionProperties))
+                .expectError(IllegalArgumentException.class)
+                .verify();
     }
 
     @Test
-    void ingestFromBlob_NullIngestionProperties_IllegalArgumentException() {
+    void ingestFromBlobAsync_NullIngestionProperties_IllegalArgumentException() {
         String path = "blobPath";
         BlobSourceInfo blobSourceInfo = new BlobSourceInfo(path);
-        assertThrows(IllegalArgumentException.class,
-                () -> streamingIngestClient.ingestFromBlob(blobSourceInfo, null),
-                "Expected IllegalArgumentException to be thrown, but it didn't");
+        StepVerifier.create(streamingIngestClient.ingestFromBlobAsync(blobSourceInfo, null))
+                .expectError(IllegalArgumentException.class)
+                .verify();
     }
 
     @ParameterizedTest
     @CsvSource(value = {"null,table", "'',table", "database,null", "database,''"}, nullValues = {"null"})
-    void ingestFromBlob_IngestionPropertiesWithIllegalDatabaseOrTableNames_IllegalArgumentException(String databaseName, String tableName) {
+    void ingestFromBlobAsync_IngestionPropertiesWithIllegalDatabaseOrTableNames_IllegalArgumentException(String databaseName, String tableName) {
         String path = "blobPath";
         BlobSourceInfo blobSourceInfo = new BlobSourceInfo(path);
         ingestionProperties = new IngestionProperties(databaseName, tableName);
-        assertThrows(IllegalArgumentException.class,
-                () -> streamingIngestClient.ingestFromBlob(blobSourceInfo, ingestionProperties),
-                "Expected IllegalArgumentException to be thrown, but it didn't");
+        StepVerifier.create(streamingIngestClient.ingestFromBlobAsync(blobSourceInfo, ingestionProperties))
+                .expectError(IllegalArgumentException.class)
+                .verify();
     }
 
     @Test
-    void ingestFromBlob_InvalidBlobPath_IngestionClientException() {
+    void ingestFromBlobAsync_InvalidBlobPath_IngestionClientException() {
         String path = "wrongURI";
         BlobSourceInfo blobSourceInfo1 = new BlobSourceInfo(path);
-        IngestionClientException ingestionClientException = assertThrows(IngestionClientException.class,
-                () -> streamingIngestClient.ingestFromBlob(blobSourceInfo1, ingestionProperties),
-                "Expected IngestionClientException to be thrown, but it didn't");
-
-        assertTrue(ingestionClientException.getMessage().contains("Unexpected error when ingesting a blob - Invalid blob path."));
+        StepVerifier.create(streamingIngestClient.ingestFromBlobAsync(blobSourceInfo1, ingestionProperties))
+                .expectErrorMatches(e -> e instanceof IngestionClientException
+                        && e.getMessage().contains("Unexpected error when ingesting a blob - Invalid blob path."))
+                .verify();
     }
 
     @Test
-    void ingestFromBlob_BlobNotFound_IngestionClientException() {
+    void ingestFromBlobAsync_BlobNotFound_IngestionClientException() {
         String path = "https://kustotest.blob.core.windows.net/container/blob.csv";
         BlobSourceInfo blobSourceInfo2 = new BlobSourceInfo(path);
-
-        IngestionClientException ingestionClientException = assertThrows(IngestionClientException.class,
-                () -> streamingIngestClient.ingestFromBlob(blobSourceInfo2, ingestionProperties),
-                "Expected IngestionClientException to be thrown, but it didn't");
-        assertTrue(ingestionClientException.getMessage().contains("Exception trying to read blob metadata"));
+        StepVerifier.create(streamingIngestClient.ingestFromBlobAsync(blobSourceInfo2, ingestionProperties))
+                .expectErrorMatches(e -> e instanceof IngestionClientException
+                        && e.getMessage().contains("Exception trying to read blob metadata"))
+                .verify();
     }
 
     @Test
     void ingestFromBlob_EmptyBlob_IngestClientException() {
-        BlobClient cloudBlockBlob = mock(BlobClient.class);
+        BlobAsyncClient cloudBlockBlob = mock(BlobAsyncClient.class);
         String blobPath = "https://kustotest.blob.core.windows.net/container/blob.csv";
         BlobSourceInfo blobSourceInfo = new BlobSourceInfo(blobPath);
 
         BlobProperties blobProperties = mock(BlobProperties.class);
         when(blobProperties.getBlobSize()).thenReturn((long) 0);
 
-        when(cloudBlockBlob.getProperties()).thenReturn(blobProperties);
-
-        IngestionClientException ingestionClientException = assertThrows(IngestionClientException.class,
-                () -> streamingIngestClient.ingestFromBlob(blobSourceInfo, ingestionProperties, cloudBlockBlob, null),
-                "Expected IngestionClientException to be thrown, but it didn't");
-        assertTrue(ingestionClientException.getMessage().contains("Empty blob."));
+        when(cloudBlockBlob.getProperties()).thenReturn(Mono.just(blobProperties));
+        StepVerifier.create(streamingIngestClient.ingestFromBlobAsync(blobSourceInfo, ingestionProperties, cloudBlockBlob, null))
+                .expectErrorMatches(e -> e instanceof IngestionClientException
+                        && e.getMessage().contains("Empty blob."))
+                .verify();
     }
 
     @Test
@@ -538,9 +564,9 @@ class StreamingIngestClientTest {
 
         ResultSetSourceInfo resultSetSourceInfo = new ResultSetSourceInfo(resultSet);
         OperationStatus status = streamingIngestClient.ingestFromResultSet(resultSetSourceInfo, ingestionProperties).getIngestionStatusCollection()
-                .get(0).status;
+                .block().get(0).status;
         assertEquals(OperationStatus.Succeeded, status);
-        verify(streamingClientMock, atLeastOnce()).executeStreamingIngest(any(String.class), any(String.class), argumentCaptor.capture(),
+        verify(streamingClientMock, atLeastOnce()).executeStreamingIngestAsync(any(String.class), any(String.class), argumentCaptor.capture(),
                 isNull(), any(String.class), isNull(), any(boolean.class));
 
         InputStream stream = argumentCaptor.getValue();
@@ -548,30 +574,30 @@ class StreamingIngestClientTest {
     }
 
     @Test
-    void ingestFromResultSet_NullResultSetSourceInfo_IllegalArgumentException() {
-        assertThrows(IllegalArgumentException.class,
-                () -> streamingIngestClient.ingestFromResultSet(null, ingestionProperties),
-                "Expected IllegalArgumentException to be thrown, but it didn't");
+    void ingestFromResultSetAsync_NullResultSetSourceInfo_IllegalArgumentException() {
+        StepVerifier.create(streamingIngestClient.ingestFromResultSetAsync(null, ingestionProperties))
+                .expectError(IllegalArgumentException.class)
+                .verify();
     }
 
     @Test
-    void ingestFromResultSet_NullIngestionProperties_IllegalArgumentException() {
+    void ingestFromResultSetAsync_NullIngestionProperties_IllegalArgumentException() {
         ResultSet resultSet = mock(ResultSet.class);
         ResultSetSourceInfo resultSetSourceInfo = new ResultSetSourceInfo(resultSet);
-        assertThrows(IllegalArgumentException.class,
-                () -> streamingIngestClient.ingestFromResultSet(resultSetSourceInfo, null),
-                "Expected IllegalArgumentException to be thrown, but it didn't");
+        StepVerifier.create(streamingIngestClient.ingestFromResultSetAsync(resultSetSourceInfo, null))
+                .expectError(IllegalArgumentException.class)
+                .verify();
     }
 
     @ParameterizedTest
     @CsvSource(value = {"null,table", "'',table", "database,null", "database,''"}, nullValues = {"null"})
-    void ingestFromResultSet_IngestionPropertiesWithIllegalDatabaseOrTableNames_IllegalArgumentException(String databaseName, String tableName) {
+    void ingestFromResultSetAsync_IngestionPropertiesWithIllegalDatabaseOrTableNames_IllegalArgumentException(String databaseName, String tableName) {
         ResultSet resultSet = mock(ResultSet.class);
         ResultSetSourceInfo resultSetSourceInfo = new ResultSetSourceInfo(resultSet);
         ingestionProperties = new IngestionProperties(databaseName, tableName);
-        assertThrows(IllegalArgumentException.class,
-                () -> streamingIngestClient.ingestFromResultSet(resultSetSourceInfo, ingestionProperties),
-                "Expected IllegalArgumentException to be thrown, but it didn't");
+        StepVerifier.create(streamingIngestClient.ingestFromResultSetAsync(resultSetSourceInfo, ingestionProperties))
+                .expectError(IllegalArgumentException.class)
+                .verify();
     }
 
     @Test
@@ -583,10 +609,10 @@ class StreamingIngestClientTest {
         when(resultSetMetaData.getColumnCount()).thenReturn(0);
 
         ResultSetSourceInfo resultSetSourceInfo = new ResultSetSourceInfo(resultSet);
-        IngestionClientException ingestionClientException = assertThrows(IngestionClientException.class,
-                () -> streamingIngestClient.ingestFromResultSet(resultSetSourceInfo, ingestionProperties),
-                "Expected IngestionClientException to be thrown, but it didn't");
-        assertTrue(ingestionClientException.getMessage().contains("Empty ResultSet."));
+        StepVerifier.create(streamingIngestClient.ingestFromResultSetAsync(resultSetSourceInfo, ingestionProperties))
+                .expectErrorMatches(e -> e instanceof IngestionClientException
+                        && e.getMessage().contains("Empty ResultSet."))
+                .verify();
     }
 
     private static Stream<Arguments> provideStringsForAutoCorrectEndpointTruePass() {

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <commons-text.version>1.11.0</commons-text.version>
         <commons-codec.version>1.17.0</commons-codec.version>
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
+        <reactor-test.version>3.6.11</reactor-test.version>
         <fasterxml.jackson.core.version>2.16.0</fasterxml.jackson.core.version>
         <univocity-parsers.version>2.9.1</univocity-parsers.version>
         <resilience4j.version>1.7.1</resilience4j.version>

--- a/samples/README.md
+++ b/samples/README.md
@@ -248,12 +248,12 @@ FileSourceInfo fileSourceInfo = new FileSourceInfo(path, new File(path).length()
 
 From stream:
 ```java
-OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status; //TODO: this is async now? should we have a sync equivalent?
 ```
 
 From File:
 ```java
-OperationStatus status = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+OperationStatus status = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status; //TODO: this is async now? should we have a sync equivalent?
 ```
 
 ### How to run this sample
@@ -331,12 +331,12 @@ IngestionResult ingestionResult = client.ingestFromFile(fileSourceInfo, ingestio
 5. Retrieve ingestion status and wait for result
 
 ```java
-List<IngestionStatus> statuses = ingestionResult.getIngestionStatusCollection();
+List<IngestionStatus> statuses = ingestionResult.getIngestionStatusCollection(); //TODO: this is async now? should we have a sync equivalent?
 
 while (statuses.get(0).status == OperationStatus.Pending && timeoutInSec > 0) {
     Thread.sleep(1000);
     timeoutInSec -= 1;
-    statuses = ingestionResult.getIngestionStatusCollection();
+    statuses = ingestionResult.getIngestionStatusCollection(); //TODO: this is async now? should we have a sync equivalent?
 }
 ```
 

--- a/samples/src/main/java/FileIngestion.java
+++ b/samples/src/main/java/FileIngestion.java
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import com.azure.data.tables.TableAsyncClient;
+import com.azure.data.tables.models.TableEntity;
 import com.microsoft.azure.kusto.data.auth.ConnectionStringBuilder;
 import com.microsoft.azure.kusto.ingest.ColumnMapping;
 import com.microsoft.azure.kusto.ingest.IngestClient;
@@ -10,6 +12,7 @@ import com.microsoft.azure.kusto.ingest.IngestionProperties;
 import com.microsoft.azure.kusto.ingest.result.IngestionResult;
 import com.microsoft.azure.kusto.ingest.source.FileSourceInfo;
 import com.microsoft.azure.kusto.ingest.source.StreamSourceInfo;
+import com.microsoft.azure.kusto.ingest.utils.TableWithSas;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -17,10 +20,10 @@ import java.io.ByteArrayOutputStream;
 public class FileIngestion {
     public static void main(String[] args) {
         try {
-            // TableClient tableClient =
-            // TableWithSas.TableClientFromUrl("https://5s8kstrldruthruth01.blob.core.windows.net/20230313-ingestdata-e5c334ee145d4b4-0?sv=2018-03-28&sr=c&sig=QshIuU9ZZ1jvcgcPMnHcr0EvCwO9sxZbvAUaAtI%3D&st=2023-03-13T13%3A16%3A57Z&se=2023-03-17T14%3A16%3A57Z&sp=rw",
+            // TableAsyncClient tableAsyncClient =
+            // TableWithSas.createTableClientFromUrl("https://5s8kstrldruthruth01.blob.core.windows.net/20230313-ingestdata-e5c334ee145d4b4-0?sv=2018-03-28&sr=c&sig=QshIuU9ZZ1jvcgcPMnHcr0EvCwO9sxZbvAUaAtI%3D&st=2023-03-13T13%3A16%3A57Z&se=2023-03-17T14%3A16%3A57Z&sp=rw",
             // null);
-            // tableClient.createEntity(new TableEntity("123", "123"));
+            // tableAsyncClient.createEntity(new TableEntity("123", "123")).block();
 
             ConnectionStringBuilder csb = ConnectionStringBuilder.createWithUserPrompt("https://ruthruth.eastus.kusto.windows.net");
             try (IngestClient client = IngestClientFactory.createClient(csb)) {

--- a/samples/src/main/java/FileIngestionCompletableFuture.java
+++ b/samples/src/main/java/FileIngestionCompletableFuture.java
@@ -27,7 +27,7 @@ public class FileIngestionCompletableFuture {
                     System.getProperty("appKey"),
                     System.getProperty("appTenant"));
 
-            CompletableFuture<IngestionResult> cf;
+            CompletableFuture<IngestionResult> cf; // TODO: adjust this to use the async API instead of using CompletableFuture or not?
             try (IngestClient client = IngestClientFactory.createClient(csb)) {
                 // Creating the ingestion properties:
                 IngestionProperties ingestionProperties = new IngestionProperties(

--- a/samples/src/main/java/Jmeter/jmeterStressTest.jmx
+++ b/samples/src/main/java/Jmeter/jmeterStressTest.jmx
@@ -409,7 +409,7 @@ try {
   } finally {
       client.close();
   }
-  IngestionStatus ingestionStatus = ingestionResult.getIngestionStatusCollection().get(0);
+  IngestionStatus ingestionStatus = ingestionResult.getIngestionStatusCollection().get(0);  //TODO: block here?
   if (ingestionStatus.status != OperationStatus.Queued){
       throw new Exception(&quot;Failed upload&quot; + ingestionStatus.errorCodeString);
   }

--- a/samples/src/main/java/StreamingIngest.java
+++ b/samples/src/main/java/StreamingIngest.java
@@ -58,7 +58,8 @@ public class StreamingIngest {
         InputStream inputStream = new ByteArrayInputStream(StandardCharsets.UTF_8.encode(data).array());
         StreamSourceInfo streamSourceInfo = new StreamSourceInfo(inputStream);
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.CSV);
-        OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+        OperationStatus status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().block()
+                .get(0).status;
         System.out.println(status.toString());
 
         String resourcesDirectory = System.getProperty("user.dir") + "/samples/src/main/resources/";
@@ -71,7 +72,7 @@ public class StreamingIngest {
          * stream content is already compressed, we should set this property true to avoid double compression.
          */
         streamSourceInfo.setCompressionType(CompressionType.gz);
-        status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+        status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().block().get(0).status;
         System.out.println(status.toString());
 
         // Open JSON File Stream and Ingest
@@ -79,7 +80,7 @@ public class StreamingIngest {
         ingestionProperties.setIngestionMapping(mapping, IngestionMapping.IngestionMappingKind.JSON);
         fileInputStream = new FileInputStream(resourcesDirectory + "dataset.json");
         streamSourceInfo.setStream(fileInputStream);
-        status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+        status = streamingIngestClient.ingestFromStream(streamSourceInfo, ingestionProperties).getIngestionStatusCollection().block().get(0).status;
         System.out.println(status.toString());
     }
 
@@ -90,7 +91,8 @@ public class StreamingIngest {
         String path = resourcesDirectory + "dataset.csv";
         FileSourceInfo fileSourceInfo = new FileSourceInfo(path, new File(path).length());
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.CSV);
-        OperationStatus status = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+        OperationStatus status = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties).getIngestionStatusCollection().block()
+                .get(0).status;
         System.out.println(status.toString());
 
         // Ingest compressed JSON file
@@ -98,7 +100,7 @@ public class StreamingIngest {
         fileSourceInfo = new FileSourceInfo(path, new File(path).length());
         ingestionProperties.setDataFormat(IngestionProperties.DataFormat.JSON);
         ingestionProperties.setIngestionMapping(mapping, IngestionMapping.IngestionMappingKind.JSON);
-        status = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties).getIngestionStatusCollection().get(0).status;
+        status = streamingIngestClient.ingestFromFile(fileSourceInfo, ingestionProperties).getIngestionStatusCollection().block().get(0).status;
         System.out.println(status.toString());
     }
 }

--- a/samples/src/main/java/TableStatus.java
+++ b/samples/src/main/java/TableStatus.java
@@ -38,13 +38,13 @@ public class TableStatus {
                 FileSourceInfo fileSourceInfo = new FileSourceInfo(System.getProperty("filePath"), 0);
                 ingestionResult = client.ingestFromFile(fileSourceInfo, ingestionProperties);
             }
-            List<IngestionStatus> statuses = ingestionResult.getIngestionStatusCollection();
+            List<IngestionStatus> statuses = ingestionResult.getIngestionStatusCollection().block(); // TODO: how to handle this
 
             // step 3: poll on the result.
             while (statuses.get(0).status == OperationStatus.Pending && timeoutInSec > 0) {
                 Thread.sleep(1000);
                 timeoutInSec -= 1;
-                statuses = ingestionResult.getIngestionStatusCollection();
+                statuses = ingestionResult.getIngestionStatusCollection().block();
             }
 
             ObjectMapper objectMapper = Utils.getObjectMapper();


### PR DESCRIPTION
### Added
- The SDK now provides Reactor Core-based asynchronous APIs for all queued and streaming ingestion endpoints,
  enabling non-blocking operations.

### Changed
- [BREAKING] All synchronous queued and streaming ingestion APIs now delegate to their asynchronous counterparts
  internally and block for results.