### PR TITLE
Enable OneBox hostnames that include the port

### DIFF
--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientBase.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientBase.java
@@ -2,6 +2,7 @@ package com.microsoft.azure.kusto.ingest;
 
 import com.microsoft.azure.kusto.data.exceptions.ExceptionUtils;
 import com.microsoft.azure.kusto.ingest.source.CompressionType;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.conn.util.InetAddressUtils;
 
 import java.io.IOException;
@@ -54,8 +55,9 @@ public abstract class IngestClientBase implements IngestClient {
         }
 
         boolean isLocalhost = authority.contains("localhost");
+        String host = StringUtils.isEmpty(uri.getHost()) ? "" : uri.getHost();
 
-        return isLocalhost || isIpAddress || uri.getHost().equalsIgnoreCase("onebox.dev.kusto.windows.net");
+        return isLocalhost || isIpAddress || host.equalsIgnoreCase("onebox.dev.kusto.windows.net");
     }
 
     protected abstract IngestionResult ingestFromFileImpl(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties)

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientBase.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientBase.java
@@ -46,17 +46,16 @@ public abstract class IngestClientBase implements IngestClient {
         }
 
         String authority = uri.getAuthority().toLowerCase();
-        boolean isIPFlag;
+        boolean isIpAddress;
         if (authority.startsWith("[") && authority.endsWith("]")) {
-            authority = authority.substring(1, authority.length() - 1);
-            isIPFlag = true;
+            isIpAddress = true;
         } else {
-            isIPFlag = InetAddressUtils.isIPv4Address(authority);
+            isIpAddress = InetAddressUtils.isIPv4Address(authority);
         }
 
-        boolean isLocalFlag = authority.contains("localhost");
+        boolean isLocalhost = authority.contains("localhost");
 
-        return isLocalFlag || isIPFlag || authority.equalsIgnoreCase("onebox.dev.kusto.windows.net");
+        return isLocalhost || isIpAddress || uri.getHost().equalsIgnoreCase("onebox.dev.kusto.windows.net");
     }
 
     protected abstract IngestionResult ingestFromFileImpl(FileSourceInfo fileSourceInfo, IngestionProperties ingestionProperties)

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientBase.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/IngestClientBase.java
@@ -1,20 +1,18 @@
 package com.microsoft.azure.kusto.ingest;
 
+import com.azure.core.util.CoreUtils;
 import com.microsoft.azure.kusto.data.exceptions.ExceptionUtils;
-import com.microsoft.azure.kusto.ingest.source.CompressionType;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.conn.util.InetAddressUtils;
-
-import java.io.IOException;
-import java.net.URI;
+import com.microsoft.azure.kusto.data.instrumentation.MonitoredActivity;
 import com.microsoft.azure.kusto.data.instrumentation.SupplierTwoExceptions;
 import com.microsoft.azure.kusto.data.instrumentation.TraceableAttributes;
-import com.microsoft.azure.kusto.data.instrumentation.MonitoredActivity;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionClientException;
 import com.microsoft.azure.kusto.ingest.exceptions.IngestionServiceException;
 import com.microsoft.azure.kusto.ingest.result.IngestionResult;
 import com.microsoft.azure.kusto.ingest.source.*;
+import org.apache.http.conn.util.InetAddressUtils;
 
+import java.io.IOException;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -55,7 +53,7 @@ public abstract class IngestClientBase implements IngestClient {
         }
 
         boolean isLocalhost = authority.contains("localhost");
-        String host = StringUtils.isEmpty(uri.getHost()) ? "" : uri.getHost();
+        String host = CoreUtils.isNullOrEmpty(uri.getHost()) ? "" : uri.getHost();
 
         return isLocalhost || isIpAddress || host.equalsIgnoreCase("onebox.dev.kusto.windows.net");
     }


### PR DESCRIPTION
### Fixed
Onebox URLs with port were rejected, and are now accepted.