### PR TITLE
Enable Quickstart to run commands, as opposed to just queries

### DIFF
--- a/quickstart/src/main/java/com/microsoft/azure/kusto/quickstart/Utils.java
+++ b/quickstart/src/main/java/com/microsoft/azure/kusto/quickstart/Utils.java
@@ -161,7 +161,7 @@ public class Utils {
             KustoOperationResult result;
 
             try {
-                result = kustoClient.executeQuery(databaseName, command, clientRequestProperties);
+                result = command.startsWith(MgmtPrefix) ? kustoClient.executeMgmt(databaseName, command, clientRequestProperties) : kustoClient.executeQuery(databaseName, command, clientRequestProperties);
                 System.out.printf("Response from executed command '%s':%n", command);
                 KustoResultSetTable primaryResults = result.getPrimaryResults();
 


### PR DESCRIPTION
### Fixed
Enable Quickstart to run commands, as opposed to just queries. I assume it previously worked, and I'm not sure why it stopped working.