### PR TITLE
Upgrade resilience4j version and remove resilience4j retry internals from azure-kusto-ingest

### DIFF
--- a/ingest/pom.xml
+++ b/ingest/pom.xml
@@ -271,9 +271,9 @@
             <version>${resilience4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.vavr</groupId>
-            <artifactId>vavr</artifactId>
-            <version>${io.vavr.version}</version>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-core</artifactId>
+            <version>${resilience4j.version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure.kusto</groupId>

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ResourceManager.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/ResourceManager.java
@@ -26,7 +26,6 @@ import com.microsoft.azure.kusto.ingest.resources.ResourceWithSas;
 import com.microsoft.azure.kusto.ingest.utils.TableWithSas;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
-import io.vavr.CheckedFunction0;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import reactor.util.annotation.Nullable;
@@ -34,7 +33,6 @@ import reactor.util.annotation.Nullable;
 import java.io.Closeable;
 import java.lang.invoke.MethodHandles;
 import java.net.URISyntaxException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Timer;
@@ -141,9 +139,8 @@ class ResourceManager implements Closeable, IngestionResourceManager {
                     log.info("Refreshing Ingestion Resources");
                     IngestionResourceSet newIngestionResourceSet = new IngestionResourceSet();
                     Retry retry = Retry.of("get ingestion resources", taskRetryConfig);
-                    CheckedFunction0<KustoOperationResult> retryExecute = Retry.decorateCheckedSupplier(retry,
-                            () -> client.executeMgmt(Commands.INGESTION_RESOURCES_SHOW_COMMAND));
-                    KustoOperationResult ingestionResourcesResults = retryExecute.apply();
+                    KustoOperationResult ingestionResourcesResults = Retry.decorateCheckedSupplier(retry,
+                            () -> client.executeMgmt(Commands.INGESTION_RESOURCES_SHOW_COMMAND)).get();
                     if (ingestionResourcesResults != null) {
                         KustoResultSetTable table = ingestionResourcesResults.getPrimaryResults();
                         // Add the received values to the new ingestion resources
@@ -237,9 +234,8 @@ class ResourceManager implements Closeable, IngestionResourceManager {
                 try {
                     log.info("Refreshing Ingestion Auth Token");
                     Retry retry = Retry.of("get Ingestion Auth Token resources", taskRetryConfig);
-                    CheckedFunction0<KustoOperationResult> retryExecute = Retry.decorateCheckedSupplier(retry,
-                            () -> client.executeMgmt(Commands.IDENTITY_GET_COMMAND));
-                    KustoOperationResult identityTokenResult = retryExecute.apply();
+                    KustoOperationResult identityTokenResult = Retry.decorateCheckedSupplier(retry,
+                            () -> client.executeMgmt(Commands.IDENTITY_GET_COMMAND)).get();
                     if (identityTokenResult != null
                             && identityTokenResult.hasNext()
                             && !identityTokenResult.getResultTables().isEmpty()) {

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,7 @@
         <apache.httpclient.version>4.5.14</apache.httpclient.version>
         <fasterxml.jackson.core.version>2.16.0</fasterxml.jackson.core.version>
         <univocity-parsers.version>2.9.1</univocity-parsers.version>
-        <resilience4j.version>1.7.1</resilience4j.version>
-        <io.vavr.version>0.10.4</io.vavr.version>
+        <resilience4j.version>2.3.0</resilience4j.version>
         <!-- Test dependencies -->
         <bouncycastle.version>1.77</bouncycastle.version>
         <jsonassert.version>1.5.0</jsonassert.version>


### PR DESCRIPTION
### Issue
We have been running a spring boot upgrade from 2.7 to 3.3.x and also upgrading the azure-kusto-java library to the latest available version. The issue is that we cannot use the latest resilience4j versions but we have to use the version 1.7.1(which was released 4 years ago) because of how it is utilized here.

### Changed
Upgraded resilience4j version from 1.7.1 to 2.3.0(latest). This was done because in version:
2.0.0 - Spring boot 2.7 is being supported
2.0.1 - Spring boot 3  is being supported
2.2.0 - Micronaut 4  is being supported

You can check their releases for more (https://github.com/resilience4j/resilience4j/releases)

### Fixed

Removed internals of resilience4j-retry library from ResourceManager.


Feel free to review this PR and mark any concern.