### PR TITLE
Make invalidlogin test not pollute the cloud cache

### DIFF
--- a/data/src/test/java/com/microsoft/azure/kusto/data/auth/WellKnownKustoEndpointsTests.java
+++ b/data/src/test/java/com/microsoft/azure/kusto/data/auth/WellKnownKustoEndpointsTests.java
@@ -167,7 +167,7 @@ public class WellKnownKustoEndpointsTests {
     @Test
     @DisplayName("validate auth with certificate throws exception when missing or invalid parameters")
     void failForInvalidLogin() throws URISyntaxException {
-        CloudInfo.manuallyAddToCache("https://resource.uri", Mono.just(new CloudInfo(
+        CloudInfo.manuallyAddToCache("https://resource2.uri", Mono.just(new CloudInfo(
                 DEFAULT_LOGIN_MFA_REQUIRED,
                 "https://InvalidLogin.uri",
                 DEFAULT_KUSTO_CLIENT_APP_ID,


### PR DESCRIPTION
### Added
### Changed
### Fixed
