### PR TITLE
Bugfix/keep alive timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ enabling non-blocking operations. You can read more about Reactor Core and [Mono
 ### Changed
 - [BREAKING] All synchronous query/management, streaming query/ingestion (StreamingClient) APIs now delegate to their asynchronous counterparts
 internally and block for results.
+- [BREAKING] Removing max keep alive from HttpClientPropertiesBuilder.
 
 ## [6.0.0-ALPHA-01] - 2024-11-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Fixed
+- Long Queries would time out after 2 minutes. Remove keep alive timeout to fix.
+
 ### Added
 - The SDK now provides Reactor Core-based asynchronous APIs for all query, management, streaming query/ingestion (StreamingClient) endpoints,
 enabling non-blocking operations. You can read more about Reactor Core and [Mono type here](https://projectreactor.io/docs/core/release/api/).

--- a/data/src/main/java/com/microsoft/azure/kusto/data/http/HttpClientFactory.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/http/HttpClientFactory.java
@@ -41,6 +41,7 @@ public class HttpClientFactory {
 
         options.setMaximumConnectionPoolSize(properties.maxConnectionTotal());
         options.setConnectionIdleTimeout(Duration.ofSeconds(properties.maxIdleTime()));
+        options.readTimeout(Duration.ofSeconds(properties.readTimeout()));
         options.setHttpClientProvider(properties.provider());
 
         // Set Keep-Alive headers if they were requested.
@@ -48,11 +49,9 @@ public class HttpClientFactory {
         if (properties.isKeepAlive()) {
             Header keepAlive = new Header(HttpHeaderName.CONNECTION.getCaseSensitiveName(), "Keep-Alive");
             // Keep-Alive is Non-standard from the client so core does not have an enum for it
-            Header keepAliveTimeout = new Header("Keep-Alive", "timeout=" + properties.maxKeepAliveTime());
 
             List<Header> headers = new ArrayList<>();
             headers.add(keepAlive);
-            headers.add(keepAliveTimeout);
 
             options.setHeaders(headers);
         }

--- a/data/src/main/java/com/microsoft/azure/kusto/data/http/HttpClientProperties.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/http/HttpClientProperties.java
@@ -3,26 +3,24 @@ package com.microsoft.azure.kusto.data.http;
 import com.azure.core.http.HttpClientProvider;
 import com.azure.core.http.ProxyOptions;
 
-import java.time.Duration;
-
 /**
  * HTTP client properties.
  */
 public class HttpClientProperties {
     private final Integer maxIdleTime;
     private final boolean keepAlive;
-    private final Integer maxKeepAliveTime;
     private final Integer maxConnectionTotal;
     private final Class<? extends HttpClientProvider> provider;
     private final ProxyOptions proxy;
+    private final Integer readTimeout;
 
     private HttpClientProperties(HttpClientPropertiesBuilder builder) {
         this.maxIdleTime = builder.maxIdleTime;
         this.keepAlive = builder.keepAlive;
-        this.maxKeepAliveTime = builder.maxKeepAliveTime;
         this.maxConnectionTotal = builder.maxConnectionsTotal;
         this.provider = builder.provider;
         this.proxy = builder.proxy;
+        this.readTimeout = builder.readTimeout;
     }
 
     /**
@@ -45,31 +43,27 @@ public class HttpClientProperties {
     }
 
     /**
-     * Indicates whether or not a custom connection keep-alive time should be used. If set to {@code false}, the HTTP
+     * The amount of time between each response data read from the network before timing out.
+     * Defaults to 1 hour.
+     * @return read timeout in seconds
+     * @see <a href="https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core/README.md#http-timeouts">azure-core timouts</a>
+     */
+    public Integer readTimeout() {
+        return readTimeout;
+    }
+
+    /**
+     * Indicates whether a custom connection keep-alive time should be used. If set to {@code false}, the HTTP
      * client will use the default connection keep-alive strategy, which is to use only the server instructions
      * (if any) set in the {@code Keep-Alive} response header.
      * If set to {@code true}, the HTTP client will use a custom connection keep-alive strategy which uses the
      * server instructions set in the {@code Keep-Alive} response header; if the response doesn't contain a
-     * {@code Keep-Alive} header, the client will use a default keep-alive period indicated by
-     * {@linkplain #maxKeepAliveTime()}.
      *
      * @return whether a custom connection keep-alive strategy should be used
-     * @see #maxKeepAliveTime()
      * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive">Keep-Alive</a>
      */
     public boolean isKeepAlive() {
         return keepAlive;
-    }
-
-    /**
-     * The time a connection can remain idle as part of the keep-alive strategy. This value is only used if
-     * {@linkplain #isKeepAlive()} is set to {@code true}.
-     * Defaults to 2 minutes.
-     *
-     * @return the maximum custom keep-alive time expressed in seconds
-     */
-    public Integer maxKeepAliveTime() {
-        return maxKeepAliveTime;
     }
 
     /**
@@ -103,12 +97,12 @@ public class HttpClientProperties {
 
         private Integer maxIdleTime = 120;
         private boolean keepAlive;
-        private Integer maxKeepAliveTime = 120;
+        private Integer readTimeout = 60 * 60;
         private Integer maxConnectionsTotal = 40;
         private Class<? extends HttpClientProvider> provider = null;
         private ProxyOptions proxy = null;
 
-        private HttpClientPropertiesBuilder() {
+        public HttpClientPropertiesBuilder() {
         }
 
         /**
@@ -130,13 +124,10 @@ public class HttpClientProperties {
          * (if any) set in the {@code Keep-Alive} response header.
          * If set to {@code true}, the HTTP client will use a custom connection keep-alive strategy which uses the
          * server instructions set in the {@code Keep-Alive} response header; if the response doesn't contain a
-         * {@code Keep-Alive} header, the client will use a default keep-alive period which is configurable via
-         * {@linkplain #maxKeepAliveTime(Integer)}.
          *
          * @param keepAlive set to {@code false} to use a default keep-alive strategy or to {@code true} to use a
          *                  custom one
          * @return the builder instance
-         * @see #maxKeepAliveTime(Integer)
          * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive">Keep-Alive</a>
          */
         public HttpClientPropertiesBuilder keepAlive(boolean keepAlive) {
@@ -145,17 +136,17 @@ public class HttpClientProperties {
         }
 
         /**
-         * Sets the time a connection can remain idle as part of the keep-alive strategy. This value is only used if
-         * {@linkplain #keepAlive(boolean)} is set to {@code true}.
-         * Defaults to 120 seconds (2 minutes).
-         *
-         * @param maxKeepAliveTime the maximum time a connection may remain idle, expressed in seconds
+         * Sets the amount of time between each response data read from the network before timing out.
+         * Defaults to 1 hour.
+         * @param readTimeout the maximum custom keep-alive time expressed in seconds
          * @return the builder instance
+         * @see <a href="https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core/README.md#http-timeouts">azure-core timouts</a>
          */
-        public HttpClientPropertiesBuilder maxKeepAliveTime(Integer maxKeepAliveTime) {
-            this.maxKeepAliveTime = maxKeepAliveTime;
+        public HttpClientPropertiesBuilder readTimeout (Integer readTimeout) {
+            this.readTimeout = readTimeout;
             return this;
         }
+
 
         /**
          * Sets the total maximum number of connections the client may keep open at the same time.

--- a/data/src/main/java/com/microsoft/azure/kusto/data/http/HttpClientProperties.java
+++ b/data/src/main/java/com/microsoft/azure/kusto/data/http/HttpClientProperties.java
@@ -142,11 +142,10 @@ public class HttpClientProperties {
          * @return the builder instance
          * @see <a href="https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/core/azure-core/README.md#http-timeouts">azure-core timouts</a>
          */
-        public HttpClientPropertiesBuilder readTimeout (Integer readTimeout) {
+        public HttpClientPropertiesBuilder readTimeout(Integer readTimeout) {
             this.readTimeout = readTimeout;
             return this;
         }
-
 
         /**
          * Sets the total maximum number of connections the client may keep open at the same time.

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/E2ETest.java
@@ -663,7 +663,7 @@ class E2ETest {
         stopWatch.start();
         // The InputStream *must* be closed by the caller to prevent memory leaks
         try (InputStream is = streamingClient.executeStreamingQuery(DB_NAME, query, clientRequestProperties);
-             BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
+                BufferedReader br = new BufferedReader(new InputStreamReader(is))) {
             StringBuilder streamedResult = new StringBuilder();
             char[] buffer = new char[65536];
             String streamedLine;

--- a/quickstart/src/main/java/com/microsoft/azure/kusto/quickstart/Utils.java
+++ b/quickstart/src/main/java/com/microsoft/azure/kusto/quickstart/Utils.java
@@ -161,7 +161,8 @@ public class Utils {
             KustoOperationResult result;
 
             try {
-                result = command.startsWith(MgmtPrefix) ? kustoClient.executeMgmt(databaseName, command, clientRequestProperties) : kustoClient.executeQuery(databaseName, command, clientRequestProperties);
+                result = command.startsWith(MgmtPrefix) ? kustoClient.executeMgmt(databaseName, command, clientRequestProperties)
+                        : kustoClient.executeQuery(databaseName, command, clientRequestProperties);
                 System.out.printf("Response from executed command '%s':%n", command);
                 KustoResultSetTable primaryResults = result.getPrimaryResults();
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -44,7 +44,6 @@ ConnectionStringBuilder csb = ConnectionStringBuilder.createWithAadApplicationCr
 
         HttpClientProperties properties = HttpClientProperties.builder()
         .keepAlive(true)
-        .maxKeepAliveTime(120)
         .maxConnectionsTotal(40)
         .build();
 

--- a/samples/src/main/java/AdvancedQuery.java
+++ b/samples/src/main/java/AdvancedQuery.java
@@ -25,7 +25,6 @@ public class AdvancedQuery {
 
             HttpClientProperties properties = HttpClientProperties.builder()
                     .keepAlive(true)
-                    .maxKeepAliveTime(120)
                     .maxConnectionsTotal(40)
                     .build();
 

--- a/samples/src/main/java/Jmeter/jmeterStressTest.jmx
+++ b/samples/src/main/java/Jmeter/jmeterStressTest.jmx
@@ -86,7 +86,6 @@ ConnectionStringBuilder csb = ConnectionStringBuilder.createWithAadApplicationCr
 
 HttpClientProperties properties = HttpClientProperties.builder()
            .keepAlive(true)
-           .maxKeepAliveTime(120)
            .maxConnectionsTotal(40)
            .build();
 
@@ -368,7 +367,6 @@ ConnectionStringBuilder dmCsb = ConnectionStringBuilder.createWithAadApplication
 Client cslClient = ClientFactory.createClient(engineCsb, (HttpClientProperties) null);
 HttpClientProperties properties = HttpClientProperties.builder()
       .keepAlive(true)
-      .maxKeepAliveTime(120)
       .maxConnectionsTotal(40)
       .build();
 

--- a/samples/src/main/java/Query.java
+++ b/samples/src/main/java/Query.java
@@ -23,7 +23,6 @@ public class Query {
 
             HttpClientProperties properties = HttpClientProperties.builder()
                     .keepAlive(true)
-                    .maxKeepAliveTime(120)
                     .maxConnectionsTotal(40)
                     .build();
 


### PR DESCRIPTION
### Fixed
- Long Queries would time out after 2 minutes. Remove keep alive timeout to fix.

### Changed
internally and block for results.
- [BREAKING] Removing max keep alive from HttpClientPropertiesBuilder.
