### PR TITLE
* Update id logic returned from the engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.0.3] - 2025-09-16
+
+### Fixed
+- Added type safe conversion of Id to UUID where response from TableEntity is a string on IngestionStatus.
+
 ## [7.0.2] - 2025-07-24
 
 ### Fixed

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionStatus.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionStatus.java
@@ -220,7 +220,7 @@ public class IngestionStatus {
         return ingestionInfo;
     }
 
-    private static UUID fromId(Object id) {
+    static UUID fromId(Object id) {
         if (id instanceof String && StringUtils.isNotBlank((String) id)) {
             try {
                 return UUID.fromString((String) id);

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionStatus.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionStatus.java
@@ -4,6 +4,7 @@
 package com.microsoft.azure.kusto.ingest.result;
 
 import com.azure.data.tables.models.TableEntity;
+import com.microsoft.azure.kusto.data.StringUtils;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -210,8 +211,8 @@ public class IngestionStatus {
         return ingestionInfo;
     }
 
-    private UUID fromId(Object id) {
-        if (id instanceof String && StringUtils.isNotEmpty((String) id)) {
+    private static UUID fromId(Object id) {
+        if (id instanceof String && StringUtils.isNotBlank((String) id)) {
             return UUID.fromString((String) id);
         } else if (id instanceof UUID) {
             return (UUID) id;
@@ -238,7 +239,7 @@ public class IngestionStatus {
         }
 
         Object activityId = tableEntity.getProperty("ActivityId");
-        ingestionStatus.setActivityId(ingestionSourceId == null ? null : (UUID) activityId);
+        ingestionStatus.setActivityId(ingestionSourceId == null ? null : fromId(activityId));
 
         ingestionStatus.setFailureStatus((String) tableEntity.getProperty("FailureStatus"));
 

--- a/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionStatus.java
+++ b/ingest/src/main/java/com/microsoft/azure/kusto/ingest/result/IngestionStatus.java
@@ -210,16 +210,25 @@ public class IngestionStatus {
         return ingestionInfo;
     }
 
+    private UUID fromId(Object id) {
+        if (id instanceof String && StringUtils.isNotEmpty((String) id)) {
+            return UUID.fromString((String) id);
+        } else if (id instanceof UUID) {
+            return (UUID) id;
+        }
+        return null;
+    }
+
     public static IngestionStatus fromEntity(TableEntity tableEntity) {
         IngestionStatus ingestionStatus = new IngestionStatus();
         Object ingestionSourceId = tableEntity.getProperty("IngestionSourceId");
-        ingestionStatus.setIngestionSourceId(ingestionSourceId == null ? null : (UUID) ingestionSourceId);
+        ingestionStatus.setIngestionSourceId(fromId(ingestionSourceId));
 
         ingestionStatus.setDatabase((String) tableEntity.getProperty("Database"));
         ingestionStatus.setTable((String) tableEntity.getProperty("Table"));
 
         Object operationId = tableEntity.getProperty("OperationId");
-        ingestionStatus.setOperationId(ingestionSourceId == null ? null : (UUID) operationId);
+        ingestionStatus.setOperationId(ingestionSourceId == null ? null : fromId(operationId));
 
         Object status = tableEntity.getProperty("Status");
         if (status instanceof String) {

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/result/IngestionStatusTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/result/IngestionStatusTest.java
@@ -1,0 +1,26 @@
+package com.microsoft.azure.kusto.ingest.result;
+
+import com.azure.data.tables.models.TableEntity;
+import com.microsoft.azure.kusto.data.StringUtils;
+
+class IngestionStatusTest {
+    static Stream<Object[]> fromIdTestCases() {
+        UUID uuid = UUID.randomUUID();
+        return Stream.of(
+                //happy path
+                new Object[]{uuid.toString(), uuid},
+                new Object[]{uuid, uuid},
+                //edge cases
+                new Object[]{"", null},
+                new Object[]{null, null},
+                new Object[]{"not-a-uuid", null}
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("fromIdTestCases")
+    void testFromId(Object input, UUID expected) {
+        UUID result = IngestionStatus.fromId(input);
+        Assertions.assertEquals(expected, result);
+    }
+}

--- a/ingest/src/test/java/com/microsoft/azure/kusto/ingest/result/IngestionStatusTest.java
+++ b/ingest/src/test/java/com/microsoft/azure/kusto/ingest/result/IngestionStatusTest.java
@@ -1,7 +1,11 @@
 package com.microsoft.azure.kusto.ingest.result;
 
 import com.azure.data.tables.models.TableEntity;
-import com.microsoft.azure.kusto.data.StringUtils;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class IngestionStatusTest {
     static Stream<Object[]> fromIdTestCases() {

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     </developers>
 
     <properties>
-        <revision>7.0.2</revision> <!-- CHANGE THIS to adjust project version-->
+        <revision>7.0.3</revision> <!-- CHANGE THIS to adjust project version-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
         <azure-bom-version>1.2.28</azure-bom-version>


### PR DESCRIPTION
### Fixed

`2025-09-16T01:56:46.2723032Z ##[error]Exception in thread "Timer-6" java.lang.ClassCastException: java.lang.String cannot be cast to java.util.UUID
2025-09-16T01:56:46.2725220Z 	at com.microsoft.azure.kusto.ingest.result.IngestionStatus.fromEntity(IngestionStatus.java:216)`

This pull request focuses on improving the robustness of UUID property handling when converting `TableEntity` objects to `IngestionStatus` objects, and also increments the project version. The most important changes are:

Entity property parsing improvements:

* Added a new private `fromId` method in `IngestionStatus.java` to safely convert entity properties to `UUID`, handling both `String` and `UUID` types and returning `null` for invalid values. Updated the usage in `fromEntity` to use this method for `IngestionSourceId` and `OperationId` properties, improving type safety and preventing potential casting errors.

Project version update:

* Bumped the project version in `pom.xml` from `7.0.2` to `7.0.3`.

