### PR TITLE
Add maven-assembly-plugin, maven-source-plugin, and dokka-maven-plugi…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,7 @@ jobs:
             staging/kusto-ingest-${{ steps.get_version.outputs.VERSION }}-sources.jar
             staging/kusto-ingest-${{ steps.get_version.outputs.VERSION }}.pom
             staging/kusto-ingest-v2-${{ steps.get_ingest_v2_version.outputs.INGEST_V2_VERSION }}.jar
+            staging/kusto-ingest-v2-${{ steps.get_ingest_v2_version.outputs.INGEST_V2_VERSION }}-jar-with-dependencies.jar
             staging/kusto-ingest-v2-${{ steps.get_ingest_v2_version.outputs.INGEST_V2_VERSION }}-javadoc.jar
             staging/kusto-ingest-v2-${{ steps.get_ingest_v2_version.outputs.INGEST_V2_VERSION }}-sources.jar
             staging/kusto-ingest-v2-${{ steps.get_ingest_v2_version.outputs.INGEST_V2_VERSION }}.pom

--- a/ingest-v2/pom.xml
+++ b/ingest-v2/pom.xml
@@ -25,6 +25,7 @@
         <slf4j.version>2.0.9</slf4j.version>
         <spotless.version>2.46.1</spotless.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <dokka.version>1.9.20</dokka.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     </properties>
     <parent>
@@ -360,6 +361,59 @@
                         <version>${kotlin.version}</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven-assembly-plugin.version}</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>${dokka.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadoc</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>javadocJar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>


### PR DESCRIPTION
This pull request enhances the build and release process for the `ingest-v2` module by introducing new Maven plugins and updating the release workflow to generate and publish additional artifact types, including a "jar-with-dependencies," source jar, and Javadoc jar. These changes improve artifact distribution and documentation.

**Build and artifact generation improvements:**

* Added the `maven-assembly-plugin` to `ingest-v2/pom.xml` to automatically create a "jar-with-dependencies" during the package phase, enabling easier distribution of a standalone jar with all dependencies included.
* Added the `maven-source-plugin` to generate and attach a sources jar during the verify phase, improving source code availability for consumers.
* Added the `dokka-maven-plugin` for generating and attaching a Javadoc jar using Dokka, enhancing documentation for Kotlin code.
* Introduced a `dokka.version` property for managing the Dokka plugin version.

**Release workflow updates:**

* Updated `.github/workflows/release.yml` to upload the new "jar-with-dependencies" artifact for `kusto-ingest-v2` as part of the release process.