### PR TITLE
Upgrade Azure SDK BOM to 1.3.6 and pin msal4j 1.24.1 for sovereign cl…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,8 @@
         <revision>7.0.7</revision> <!-- CHANGE THIS to adjust project version-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <azure-bom-version>1.2.28</azure-bom-version>
+        <azure-bom-version>1.3.6</azure-bom-version>
+        <msal4j.version>1.24.1</msal4j.version>
         <!-- Versions below are for several dependencies we're using in the data & ingest modules -->
         <!-- Ideally, versions below should align with latest databricks runtime dependency versions -->
         <!-- Compile dependencies -->
@@ -82,7 +83,15 @@
         <module>samples</module>
         <module>quickstart</module>
     </modules>
-
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>msal4j</artifactId>
+                <version>${msal4j.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>

--- a/quickstart/pom.xml
+++ b/quickstart/pom.xml
@@ -40,6 +40,8 @@
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <slf4j.version>1.8.0-beta4</slf4j.version>
         <json.version>20201115</json.version>
+        <azure-identity.version>1.18.2</azure-identity.version>
+        <msal4j.version>1.24.1</msal4j.version>
     </properties>
 
     <build>
@@ -111,6 +113,11 @@
                 <version>1.31.0</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.microsoft.azure</groupId>
+                <artifactId>msal4j</artifactId>
+                <version>${msal4j.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This pull request updates dependency management for Azure libraries and introduces the `msal4j` library across the project. The main changes include upgrading the Azure BOM version, adding and managing the `msal4j` dependency, and aligning versions in both the root and `quickstart` module `pom.xml` files.

**Dependency upgrades and additions:**

* Upgraded the `azure-bom-version` from `1.2.28` to `1.3.6` in the root `pom.xml`, ensuring newer Azure SDK versions are used.
* Added the `msal4j.version` property and set it to `1.24.1` in both the root and `quickstart/pom.xml` files for consistent version management. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L38-R39) [[2]](diffhunk://#diff-03ac261ff9b677b6933882dae645f02ca88bb0acff5448beba78b2a3dd549a99R43-R44)
* Added the `azure-identity.version` property set to `1.18.2` in `quickstart/pom.xml` to facilitate Azure authentication features.

**Dependency management configuration:**

* Added a `dependencyManagement` section in the root `pom.xml` to centrally manage the `msal4j` dependency version for all modules.
* Added the `msal4j` dependency to the `dependencyManagement` section in `quickstart/pom.xml` to ensure consistent usage within the module.

---------

### Added
### Changed
### Fixed
