### PR TITLE
Ingest V2: propagate S2S Fabric Private Link auth to OneLake uploader

### DIFF
--- a/ingest-v2/src/main/kotlin/com/microsoft/azure/kusto/ingest/v2/builders/BaseIngestClientBuilder.kt
+++ b/ingest-v2/src/main/kotlin/com/microsoft/azure/kusto/ingest/v2/builders/BaseIngestClientBuilder.kt
@@ -160,6 +160,13 @@ abstract class BaseIngestClientBuilder<T : BaseIngestClientBuilder<T>> {
             .withMaxConcurrency(maxConcurrency)
             .withMaxDataSize(maxDataSize)
             .apply { tokenCredential?.let { withTokenCredential(it) } }
+            .apply {
+                s2sTokenProvider?.let { provider ->
+                    s2sFabricPrivateLinkAccessContext?.let { context ->
+                        withFabricPrivateLink(provider, context)
+                    }
+                }
+            }
             .build()
     }
 }

--- a/ingest-v2/src/main/kotlin/com/microsoft/azure/kusto/ingest/v2/uploader/ContainerUploaderBase.kt
+++ b/ingest-v2/src/main/kotlin/com/microsoft/azure/kusto/ingest/v2/uploader/ContainerUploaderBase.kt
@@ -19,6 +19,7 @@ import com.microsoft.azure.kusto.ingest.v2.UPLOAD_MAX_SINGLE_SIZE_BYTES
 import com.microsoft.azure.kusto.ingest.v2.common.ConfigurationCache
 import com.microsoft.azure.kusto.ingest.v2.common.IngestRetryPolicy
 import com.microsoft.azure.kusto.ingest.v2.common.exceptions.IngestException
+import com.microsoft.azure.kusto.ingest.v2.common.models.S2SToken
 import com.microsoft.azure.kusto.ingest.v2.source.BlobSource
 import com.microsoft.azure.kusto.ingest.v2.source.CompressionType
 import com.microsoft.azure.kusto.ingest.v2.source.LocalSource
@@ -56,10 +57,25 @@ abstract class ContainerUploaderBase(
     protected val configurationCache: ConfigurationCache,
     private val uploadMethod: UploadMethod,
     private val tokenCredential: TokenCredential?,
+    private val s2sTokenProvider: (suspend () -> S2SToken)? = null,
+    private val s2sFabricPrivateLinkAccessContext: String? = null,
 ) : IUploader {
 
     protected val logger: Logger =
         LoggerFactory.getLogger(ContainerUploaderBase::class.java)
+
+    /**
+     * Policy that injects S2S Fabric Private Link headers into OneLake upload
+     * requests. Created once and shared across uploads; null when no S2S token
+     * provider is configured.
+     */
+    private val s2sFabricPrivateLinkPolicy: S2SFabricPrivateLinkPolicy? =
+        s2sTokenProvider?.let {
+            S2SFabricPrivateLinkPolicy(
+                it,
+                s2sFabricPrivateLinkAccessContext,
+            )
+        }
 
     private val effectiveMaxConcurrency: Int =
         minOf(maxConcurrency, Runtime.getRuntime().availableProcessors())
@@ -656,6 +672,9 @@ abstract class ContainerUploaderBase(
                     DataLakeServiceClientBuilder()
                         .endpoint(serviceEndpoint)
                         .credential(tokenCredential)
+                        .apply {
+                            s2sFabricPrivateLinkPolicy?.let { addPolicy(it) }
+                        }
                         .buildClient()
 
                 val fileSystemClient =
@@ -672,6 +691,9 @@ abstract class ContainerUploaderBase(
                 val serviceClient =
                     DataLakeServiceClientBuilder()
                         .endpoint("$serviceEndpoint?$sas")
+                        .apply {
+                            s2sFabricPrivateLinkPolicy?.let { addPolicy(it) }
+                        }
                         .buildClient()
 
                 val fileSystemClient =
@@ -688,6 +710,9 @@ abstract class ContainerUploaderBase(
                 val serviceClient =
                     DataLakeServiceClientBuilder()
                         .endpoint(serviceEndpoint)
+                        .apply {
+                            s2sFabricPrivateLinkPolicy?.let { addPolicy(it) }
+                        }
                         .buildClient()
 
                 val fileSystemClient =

--- a/ingest-v2/src/main/kotlin/com/microsoft/azure/kusto/ingest/v2/uploader/ManagedUploader.kt
+++ b/ingest-v2/src/main/kotlin/com/microsoft/azure/kusto/ingest/v2/uploader/ManagedUploader.kt
@@ -7,6 +7,7 @@ import com.microsoft.azure.kusto.ingest.v2.common.ConfigurationCache
 import com.microsoft.azure.kusto.ingest.v2.common.IngestRetryPolicy
 import com.microsoft.azure.kusto.ingest.v2.common.SimpleRetryPolicy
 import com.microsoft.azure.kusto.ingest.v2.common.exceptions.IngestException
+import com.microsoft.azure.kusto.ingest.v2.common.models.S2SToken
 
 class ManagedUploader
 internal constructor(
@@ -17,6 +18,8 @@ internal constructor(
     uploadMethod: UploadMethod = UploadMethod.DEFAULT,
     ingestRetryPolicy: IngestRetryPolicy = SimpleRetryPolicy(),
     tokenCredential: TokenCredential? = null,
+    s2sTokenProvider: (suspend () -> S2SToken)? = null,
+    s2sFabricPrivateLinkAccessContext: String? = null,
 ) :
     ContainerUploaderBase(
         maxConcurrency = maxConcurrency,
@@ -25,6 +28,9 @@ internal constructor(
         uploadMethod = uploadMethod,
         retryPolicy = ingestRetryPolicy,
         tokenCredential = tokenCredential,
+        s2sTokenProvider = s2sTokenProvider,
+        s2sFabricPrivateLinkAccessContext =
+        s2sFabricPrivateLinkAccessContext,
     ) {
 
     companion object {

--- a/ingest-v2/src/main/kotlin/com/microsoft/azure/kusto/ingest/v2/uploader/ManagedUploaderBuilder.kt
+++ b/ingest-v2/src/main/kotlin/com/microsoft/azure/kusto/ingest/v2/uploader/ManagedUploaderBuilder.kt
@@ -8,6 +8,7 @@ import com.microsoft.azure.kusto.ingest.v2.UPLOAD_CONTAINER_MAX_DATA_SIZE_BYTES
 import com.microsoft.azure.kusto.ingest.v2.common.ConfigurationCache
 import com.microsoft.azure.kusto.ingest.v2.common.IngestRetryPolicy
 import com.microsoft.azure.kusto.ingest.v2.common.SimpleRetryPolicy
+import com.microsoft.azure.kusto.ingest.v2.common.models.S2SToken
 
 /** Builder for creating ManagedUploader instances with a fluent API. */
 class ManagedUploaderBuilder private constructor() {
@@ -18,6 +19,8 @@ class ManagedUploaderBuilder private constructor() {
     private var uploadMethod: UploadMethod = UploadMethod.DEFAULT
     private var ingestRetryPolicy: IngestRetryPolicy = SimpleRetryPolicy()
     private var tokenCredential: TokenCredential? = null
+    private var s2sTokenProvider: (suspend () -> S2SToken)? = null
+    private var s2sFabricPrivateLinkAccessContext: String? = null
 
     companion object {
         /** Creates a new ManagedUploaderBuilder instance. */
@@ -115,6 +118,39 @@ class ManagedUploaderBuilder private constructor() {
     }
 
     /**
+     * Configures S2S (Service-to-Service) authentication for OneLake uploads in
+     * Fabric Private Link scenarios.
+     *
+     * When set, the S2S headers (matching the behavior of the main ingest
+     * client) are injected into every outgoing request to the OneLake storage
+     * endpoint.
+     *
+     * The provider is invoked once per outgoing OneLake request (and on each
+     * retry attempt), so it should be thread-safe and return a cached,
+     * expiry-aware token rather than acquiring a new one on every call.
+     *
+     * @param s2sTokenProvider A suspend function that provides the S2S token
+     * @param s2sFabricPrivateLinkAccessContext Specifies the scope of the
+     *   Fabric Private Link perimeter, such as the entire tenant or a specific
+     *   workspace. Must not be blank.
+     * @return this builder instance for method chaining
+     * @throws IllegalArgumentException if s2sFabricPrivateLinkAccessContext is
+     *   blank
+     */
+    fun withFabricPrivateLink(
+        s2sTokenProvider: suspend () -> S2SToken,
+        s2sFabricPrivateLinkAccessContext: String,
+    ): ManagedUploaderBuilder {
+        require(s2sFabricPrivateLinkAccessContext.isNotBlank()) {
+            "s2sFabricPrivateLinkAccessContext must not be blank"
+        }
+        this.s2sTokenProvider = s2sTokenProvider
+        this.s2sFabricPrivateLinkAccessContext =
+            s2sFabricPrivateLinkAccessContext
+        return this
+    }
+
+    /**
      * Builds and returns a ManagedUploader instance with the configured
      * settings.
      *
@@ -135,6 +171,9 @@ class ManagedUploaderBuilder private constructor() {
             uploadMethod = uploadMethod,
             ingestRetryPolicy = ingestRetryPolicy,
             tokenCredential = tokenCredential,
+            s2sTokenProvider = s2sTokenProvider,
+            s2sFabricPrivateLinkAccessContext =
+            s2sFabricPrivateLinkAccessContext,
         )
     }
 }

--- a/ingest-v2/src/main/kotlin/com/microsoft/azure/kusto/ingest/v2/uploader/S2SFabricPrivateLinkPolicy.kt
+++ b/ingest-v2/src/main/kotlin/com/microsoft/azure/kusto/ingest/v2/uploader/S2SFabricPrivateLinkPolicy.kt
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.azure.kusto.ingest.v2.uploader
+
+import com.azure.core.http.HttpPipelineCallContext
+import com.azure.core.http.HttpPipelineNextPolicy
+import com.azure.core.http.HttpPipelineNextSyncPolicy
+import com.azure.core.http.HttpResponse
+import com.azure.core.http.policy.HttpPipelinePolicy
+import com.microsoft.azure.kusto.ingest.v2.HEADER_MS_FABRIC_S2S_ACCESS_CONTEXT
+import com.microsoft.azure.kusto.ingest.v2.HEADER_MS_S2S_ACTOR_AUTHORIZATION
+import com.microsoft.azure.kusto.ingest.v2.common.models.S2SToken
+import kotlinx.coroutines.runBlocking
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+
+/**
+ * Pipeline policy that injects S2S (Service-to-Service) Fabric Private Link
+ * headers into outgoing OneLake (Data Lake) storage requests.
+ *
+ * This mirrors the header names and value format used by [com.microsoft.azure.kusto.ingest.v2.KustoBaseApiClient]
+ * for the main ingest endpoint, so that uploads to OneLake under a Fabric
+ * Private Link perimeter are authorized the same way:
+ * - `x-ms-s2s-actor-authorization` -> `"{scheme} {token}"`
+ * - `x-ms-fabric-s2s-access-context` -> the access context string
+ *
+ * The token is retrieved per request via [s2sTokenProvider] so that long-running
+ * or retried uploads always carry a fresh token. The provided callback must be
+ * thread-safe, as the policy may be invoked concurrently for parallel uploads.
+ *
+ * @property s2sTokenProvider Suspend callback returning the current S2S token.
+ * @property s2sFabricPrivateLinkAccessContext Optional access context describing
+ *   the scope of the Fabric Private Link perimeter (e.g., tenant or workspace).
+ */
+internal class S2SFabricPrivateLinkPolicy(
+    private val s2sTokenProvider: suspend () -> S2SToken,
+    private val s2sFabricPrivateLinkAccessContext: String?,
+) : HttpPipelinePolicy {
+
+    private fun applyHeaders(context: HttpPipelineCallContext, token: S2SToken) {
+        val headers = context.httpRequest.headers
+        headers.set(HEADER_MS_S2S_ACTOR_AUTHORIZATION, token.toHeaderValue())
+        s2sFabricPrivateLinkAccessContext?.let {
+            headers.set(HEADER_MS_FABRIC_S2S_ACCESS_CONTEXT, it)
+        }
+    }
+
+    override fun process(
+        context: HttpPipelineCallContext,
+        next: HttpPipelineNextPolicy,
+    ): Mono<HttpResponse> =
+        Mono.fromCallable { runBlocking { s2sTokenProvider() } }
+            .subscribeOn(Schedulers.boundedElastic())
+            .flatMap { token ->
+                applyHeaders(context, token)
+                next.process()
+            }
+
+    override fun processSync(
+        context: HttpPipelineCallContext,
+        next: HttpPipelineNextSyncPolicy,
+    ): HttpResponse {
+        val token = runBlocking { s2sTokenProvider() }
+        applyHeaders(context, token)
+        return next.processSync()
+    }
+}

--- a/ingest-v2/src/test/kotlin/com/microsoft/azure/kusto/ingest/v2/uploader/ManagedUploaderBuilderTest.kt
+++ b/ingest-v2/src/test/kotlin/com/microsoft/azure/kusto/ingest/v2/uploader/ManagedUploaderBuilderTest.kt
@@ -5,6 +5,7 @@ package com.microsoft.azure.kusto.ingest.v2.uploader
 import com.azure.core.credential.TokenCredential
 import com.microsoft.azure.kusto.ingest.v2.common.ConfigurationCache
 import com.microsoft.azure.kusto.ingest.v2.common.IngestRetryPolicy
+import com.microsoft.azure.kusto.ingest.v2.common.models.S2SToken
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -176,5 +177,28 @@ class ManagedUploaderBuilderTest {
                 .build()
 
         assertNotNull(uploader)
+    }
+
+    @Test
+    fun `withFabricPrivateLink with valid context should succeed`() {
+        val uploader =
+            ManagedUploaderBuilder.create()
+                .withConfigurationCache(mockConfigurationCache)
+                .withTokenCredential(mockTokenCredential)
+                .withFabricPrivateLink(
+                    { S2SToken.bearer("token") },
+                    "workspace-context",
+                )
+                .build()
+
+        assertNotNull(uploader)
+    }
+
+    @Test
+    fun `withFabricPrivateLink with blank context should throw exception`() {
+        val builder = ManagedUploaderBuilder.create()
+        assertThrows<IllegalArgumentException> {
+            builder.withFabricPrivateLink({ S2SToken.bearer("token") }, "  ")
+        }
     }
 }

--- a/ingest-v2/src/test/kotlin/com/microsoft/azure/kusto/ingest/v2/uploader/S2SFabricPrivateLinkPolicyTest.kt
+++ b/ingest-v2/src/test/kotlin/com/microsoft/azure/kusto/ingest/v2/uploader/S2SFabricPrivateLinkPolicyTest.kt
@@ -1,0 +1,218 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+package com.microsoft.azure.kusto.ingest.v2.uploader
+
+import com.azure.core.http.HttpClient
+import com.azure.core.http.HttpMethod
+import com.azure.core.http.HttpPipeline
+import com.azure.core.http.HttpPipelineBuilder
+import com.azure.core.http.HttpRequest
+import com.azure.core.http.HttpResponse
+import com.azure.core.util.Context
+import com.microsoft.azure.kusto.ingest.v2.HEADER_MS_FABRIC_S2S_ACCESS_CONTEXT
+import com.microsoft.azure.kusto.ingest.v2.HEADER_MS_S2S_ACTOR_AUTHORIZATION
+import com.microsoft.azure.kusto.ingest.v2.common.models.S2SToken
+import io.mockk.every
+import io.mockk.mockk
+import reactor.core.publisher.Mono
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class S2SFabricPrivateLinkPolicyTest {
+
+    /**
+     * Fake HttpClient that captures every request it sends so tests can assert
+     * which headers were present on the wire. Supports both the async and sync
+     * pipeline paths.
+     */
+    private class CapturingHttpClient : HttpClient {
+        val requests = ConcurrentLinkedQueue<HttpRequest>()
+
+        private fun response(): HttpResponse = mockk(relaxed = true)
+
+        override fun send(request: HttpRequest): Mono<HttpResponse> {
+            requests.add(request)
+            return Mono.just(response())
+        }
+
+        override fun sendSync(
+            request: HttpRequest,
+            context: Context,
+        ): HttpResponse {
+            requests.add(request)
+            return response()
+        }
+    }
+
+    private fun pipeline(
+        client: HttpClient,
+        provider: suspend () -> S2SToken,
+        accessContext: String?,
+    ): HttpPipeline =
+        HttpPipelineBuilder()
+            .httpClient(client)
+            .policies(S2SFabricPrivateLinkPolicy(provider, accessContext))
+            .build()
+
+    private fun request(): HttpRequest =
+        HttpRequest(
+            HttpMethod.PUT,
+            "https://onelake.dfs.fabric.microsoft.com/ws/lh/Files/blob",
+        )
+
+    @Test
+    fun `processSync injects both S2S headers`() {
+        val client = CapturingHttpClient()
+        val pipeline =
+            pipeline(
+                client,
+                { S2SToken.bearer("tok") },
+                "ctx",
+            )
+
+        pipeline.sendSync(request(), Context.NONE)
+
+        val sent = client.requests.single()
+        assertEquals(
+            "Bearer tok",
+            sent.headers.getValue(HEADER_MS_S2S_ACTOR_AUTHORIZATION),
+        )
+        assertEquals(
+            "ctx",
+            sent.headers.getValue(HEADER_MS_FABRIC_S2S_ACCESS_CONTEXT),
+        )
+    }
+
+    @Test
+    fun `process injects both S2S headers`() {
+        val client = CapturingHttpClient()
+        val pipeline =
+            pipeline(
+                client,
+                { S2SToken.bearer("tok") },
+                "ctx",
+            )
+
+        pipeline.send(request()).block()
+
+        val sent = client.requests.single()
+        assertEquals(
+            "Bearer tok",
+            sent.headers.getValue(HEADER_MS_S2S_ACTOR_AUTHORIZATION),
+        )
+        assertEquals(
+            "ctx",
+            sent.headers.getValue(HEADER_MS_FABRIC_S2S_ACCESS_CONTEXT),
+        )
+    }
+
+    @Test
+    fun `set replaces a stale S2S authorization header`() {
+        val client = CapturingHttpClient()
+        val pipeline =
+            pipeline(
+                client,
+                { S2SToken.bearer("fresh") },
+                "ctx",
+            )
+
+        val req =
+            request().apply {
+                headers.set(HEADER_MS_S2S_ACTOR_AUTHORIZATION, "Bearer stale")
+            }
+        pipeline.sendSync(req, Context.NONE)
+
+        assertEquals(
+            "Bearer fresh",
+            client.requests
+                .single()
+                .headers
+                .getValue(HEADER_MS_S2S_ACTOR_AUTHORIZATION),
+        )
+    }
+
+    @Test
+    fun `null access context omits access context header`() {
+        val client = CapturingHttpClient()
+        val pipeline =
+            pipeline(
+                client,
+                { S2SToken.bearer("tok") },
+                null,
+            )
+
+        pipeline.sendSync(request(), Context.NONE)
+
+        val sent = client.requests.single()
+        assertEquals(
+            "Bearer tok",
+            sent.headers.getValue(HEADER_MS_S2S_ACTOR_AUTHORIZATION),
+        )
+        assertNull(sent.headers.getValue(HEADER_MS_FABRIC_S2S_ACCESS_CONTEXT))
+    }
+
+    @Test
+    fun `provider exception propagates on sync path`() {
+        val client = CapturingHttpClient()
+        val pipeline =
+            pipeline(
+                client,
+                { throw IllegalStateException("boom") },
+                "ctx",
+            )
+
+        assertFailsWith<IllegalStateException> {
+            pipeline.sendSync(request(), Context.NONE)
+        }
+        assertTrue(client.requests.isEmpty())
+    }
+
+    @Test
+    fun `provider exception propagates on async path`() {
+        val client = CapturingHttpClient()
+        val pipeline =
+            pipeline(
+                client,
+                { throw IllegalStateException("boom") },
+                "ctx",
+            )
+
+        assertFailsWith<IllegalStateException> {
+            pipeline.send(request()).block()
+        }
+        assertTrue(client.requests.isEmpty())
+    }
+
+    @Test
+    fun `policy is safe under concurrent requests`() {
+        val client = CapturingHttpClient()
+        val pipeline =
+            pipeline(
+                client,
+                { S2SToken.bearer("tok") },
+                "ctx",
+            )
+
+        val threads =
+            (1..16).map {
+                Thread { pipeline.sendSync(request(), Context.NONE) }
+            }
+        threads.forEach { it.start() }
+        threads.forEach { it.join() }
+
+        assertEquals(16, client.requests.size)
+        assertTrue(
+            client.requests.all {
+                it.headers.getValue(HEADER_MS_S2S_ACTOR_AUTHORIZATION) ==
+                    "Bearer tok" &&
+                    it.headers.getValue(
+                        HEADER_MS_FABRIC_S2S_ACCESS_CONTEXT,
+                    ) == "ctx"
+            },
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Ports the .NET `Kusto.Ingest.V2` OneLake S2S auth fix to the Kotlin `ingest-v2` module so the SDKs stay in sync and OneLake/lake uploads work under a Fabric Private Link perimeter.

Previously, the main ingest client injected the Service-to-Service (S2S) Fabric Private Link headers on its endpoint, but the **OneLake (Data Lake) upload path** built a `DataLakeServiceClient` **without** those headers — leaving the rest/lake upload path unauthorized under Private Link.

## Changes
- **New** `S2SFabricPrivateLinkPolicy` — an azure-core `HttpPipelinePolicy` (both `process` async + `processSync`) that fetches the S2S token per request and sets:
  - `x-ms-s2s-actor-authorization` → `"{scheme} {token}"`
  - `x-ms-fabric-s2s-access-context` → access context
- `ContainerUploaderBase` — injects the policy on `DataLakeServiceClientBuilder` in all three auth branches (token / SAS / anonymous), mirroring the .NET always-add behavior.
- Threads `s2sTokenProvider` + `s2sFabricPrivateLinkAccessContext` from `BaseIngestClientBuilder` → `ManagedUploaderBuilder`/`ManagedUploader` → `ContainerUploaderBase`. `ManagedUploaderBuilder.withFabricPrivateLink` requires a non-blank access context.

## Tests
- New unit tests for the policy: sync/async header injection, stale-header replacement, null context omission, provider-exception propagation (sync + async), concurrency safety.
- Builder validation tests (non-blank context required).
- Full `ingest-v2` unit suite passes.

## Validation
End-to-end against a live PPE cluster (`ingest-sdkse2etestppe`): `QueuedIngestClientTest` — **18 run, 0 failures, 1 skipped** (OneLake test gated on `ONE_LAKE_FOLDER`). Live STORAGE uploads + queued ingestion succeeded.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>